### PR TITLE
Modified connect method so tls.connect options can be supplied.

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -49,17 +49,19 @@ function openOptionsFromURL(parts) {
   };
 }
 
-function connect(url) {
+function connect(url,connOptions) {  
   url = url || 'amqp://localhost';
-
   var parts = URL.parse(url, true); // yes, parse the query string
   var protocol = parts.protocol;
   var net;
+  var connectEvent;
   if (protocol === 'amqp:') {
     net = require('net');
+    connectEvent = 'connect';
   }
   else if (protocol === 'amqps:') {
     net = require('tls');
+    connectEvent = 'secureConnect';
   }
   else {
     throw new Error("Expected amqp: or amqps: as the protocol; got " + protocol);
@@ -72,9 +74,16 @@ function connect(url) {
   var result = defer();
 
   var sockok = false;
-
-  var sock = net.connect(port, parts.hostname);
-  sock.on('connect', function() {
+  if (protocol === 'amqps:') {
+    if (connOptions) {
+      var sock = net.connect(port, parts.hostname, connOptions);
+    } else {
+      var sock = net.connect(port, parts.hostname);
+    }
+  } else {
+    var sock = net.connect(port, parts.hostname);
+  }
+  sock.on(connectEvent, function() {
     sockok = true;
     var c = new Connection(sock);
     c.open(options).then(function (_openok) { result.resolve(c); },

--- a/lib/channel_api.js
+++ b/lib/channel_api.js
@@ -21,8 +21,8 @@ inherits(ChannelModel, EventEmitter);
 
 module.exports.ChannelModel = ChannelModel;
 
-function connect(url) {
-  return api.connect(url).then(ChannelModel);
+function connect(url, connOptions) {
+  return api.connect(url, connOptions).then(ChannelModel);
 };
 
 module.exports.connect = connect;


### PR DESCRIPTION
To connect with tls using certificates, one needs to pass the [options](http://nodejs.org/api/tls.html#tls_tls_connect_port_host_options_callback) such as key, cert, and ca.

I modified the connect method slightly to allow passing those options to tls.connect.

I also modified the listen event to listen for the event 'secureConnect' as defined in the [tls documentation](http://nodejs.org/api/tls.html#tls_event_secureconnect).

I hope you find this useful.  Thanks for the great libraries.
