### PR TITLE
queue.delete in RabbitMQ 3.2 is idempotent

### DIFF
--- a/test/channel_api.js
+++ b/test/channel_api.js
@@ -145,7 +145,7 @@ chtest("delete queue", function(ch) {
 });
 
 chtest("fail to delete no queue", function(ch) {
-  return expectFail(ch.deleteQueue('test.random-' + randomString()));
+  return ch.deleteQueue('test.random-' + randomString());
 });
 
 chtest("delete exchange", function(ch) {


### PR DESCRIPTION
and does not raise an error when the queue does not exist.

Travis CI already provisions 3.2.
