### PR TITLE
Fix support for publishing messages that have a zero-length body

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -518,8 +518,20 @@ C.sendMessage = function(channel,
     var offset = 0;
     offset += mframe.copy(all, 0);
     offset += pframe.copy(all, offset);
-    makeBodyFrame(channel, content).copy(all, offset);
-    return buffer.write(all);
+    
+    // only append a body frame if we actually have a body
+    if (content.length > 0) {
+      offset += makeBodyFrame(channel, content).copy(all, offset);
+    }
+    
+    // strip any extra space off the end of our buffer, or we'll get an 
+    // invalid_frame_end_marker error
+    if (offset < allLen) {
+      return buffer.write(all.slice(0,offset));
+    }
+    else {
+      return buffer.write(all);      
+    }
   }
   else {
     buffer.write(mframe);


### PR DESCRIPTION
The new path for short messages introduced in 27834eedc broke publishing for
messages with a content length of zero.  This commit corrects that by only
appending a body frame if we have content (which is the same as the behavior
in the longer path).

This is sort of the inverse of the issue we fixed in #10.

I would love to add a test for this, but looking at the stuff in test/ I wasn't entirely sure where to add it.
