### PR TITLE
Unable to npm install as amqp.json download fails.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 RABBITMQ_SRC_VERSION=rabbitmq_v3_2_1
 JSON=amqp-rabbitmq-0.9.1.json
-RABBITMQ_CODEGEN=https://raw.github.com/rabbitmq/rabbitmq-codegen
+RABBITMQ_CODEGEN=https://raw.githubusercontent.com/rabbitmq/rabbitmq-codegen
 AMQP_JSON=$(RABBITMQ_CODEGEN)/$(RABBITMQ_SRC_VERSION)/$(JSON)
 
 MOCHA=./node_modules/.bin/mocha


### PR DESCRIPTION
The following happens when I attempt to install this repository.

``` bash
$ npm install

> amqplib@0.1.3 prepublish /Users/philipstevens/Personal/nodejs/amqp.node
> make

curl https://raw.github.com/rabbitmq/rabbitmq-codegen/rabbitmq_v3_2_1/amqp-rabbitmq-0.9.1.json > bin/amqp-rabbitmq-0.9.1.json
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
(cd bin; node ./generate-defs.js > ../lib/defs.js)

module.js:485
    throw err;
          ^
SyntaxError: /Users/philipstevens/Personal/nodejs/amqp.node/bin/amqp-rabbitmq-0.9.1.json: Unexpected end of input
    at Object.parse (native)
    at Object.Module._extensions..json (module.js:482:27)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/Users/philipstevens/Personal/nodejs/amqp.node/bin/generate-defs.js:4:12)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
make: *** [lib/defs.js] Error 8

npm ERR! amqplib@0.1.3 prepublish: `make`
npm ERR! Exit status 2
npm ERR!
npm ERR! Failed at the amqplib@0.1.3 prepublish script.
npm ERR! This is most likely a problem with the amqplib package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     make
npm ERR! You can get their info via:
npm ERR!     npm owner ls amqplib
npm ERR! There is likely additional logging output above.
npm ERR! System Darwin 13.1.0
npm ERR! command "/usr/local/Cellar/node/0.10.26/bin/node" "/usr/local/bin/npm" "install"
npm ERR! cwd /Users/philipstevens/Personal/nodejs/amqp.node
npm ERR! node -v v0.10.26
npm ERR! npm -v 1.4.3
npm ERR! code ELIFECYCLE
npm ERR!
npm ERR! Additional logging details can be found in:
npm ERR!     /Users/philipstevens/Personal/nodejs/amqp.node/npm-debug.log
npm ERR! not ok code 0
```

I am running v0.10.26 of node and v1.4.3 of npm.

Changing the URL to 

``` bash
RABBITMQ_CODEGEN=https://raw.githubusercontent.com/rabbitmq/rabbitmq-codegen
```

Seems to fix this problem, and all tests pass. What confuses me is that I can curl the address from command line without an issue, but it fails within this run script ...

``` bash
$ curl https://raw.github.com/rabbitmq/rabbitmq-codegen/rabbitmq_v3_2_1/amqp-rabbitmq-0.9.1.json > amqp-rabbitmq-0.9.1.json
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:00:02 --:--:--     0
```

But I submit this as a quick solution to this issue in case any one else suffers from it.
