### PR TITLE
Correctly handle vhost in connection urls.

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -52,7 +52,7 @@ function openOptionsFromURL(parts) {
   if (!vhost)
     vhost = '/';
   else
-    vhost = QS.unescape(vhost.substr(1));
+    vhost = QS.unescape(vhost);
 
   var q = parts.query || {};
 


### PR DESCRIPTION
It is possible to pass the url of a RabbitMQ server in the format

ampq://user:pass@hostname:port/vhost

However the leading slash for the vhost was mistakenly stripped which caused
urls that included a path not to work properly. This patch fixes the issue.

---

I briefly looked into writing a test for this but I think we'd need to expose more from `lib/connect.js` to achieve this.
