### PR TITLE
Fixed bug where options passed through to callback_api.js are not taken through to connection

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -103,7 +103,7 @@ function connect(url, socketOptions, openCallback) {
     sockok = true;
     sock.setNoDelay(noDelay);
     var c = new Connection(sock);
-    c.open(options, function(err, ok) {
+    c.open(merge_options(options, sockopts), function(err, ok) {
       if (err === null) openCallback(null, c);
       else openCallback(err);
     });
@@ -123,6 +123,13 @@ function connect(url, socketOptions, openCallback) {
     if (!sockok) openCallback(err);
   });
 
+}
+
+function merge_options(obj1,obj2){
+    var obj3 = {};
+    for (var attrname in obj1) { obj3[attrname] = obj1[attrname]; }
+    for (var attrname in obj2) { obj3[attrname] = obj2[attrname]; }
+    return obj3;
 }
 
 module.exports.connect = connect;


### PR DESCRIPTION
Pretty sure this should pass options through should it not?

I try:

amqp.connect("amqp://localhost", { heartbeat: 15 }, on_connect);

and rabbitmq did not register any form of time out. 

I needed to fix this quickly so jumped in. 
