### PR TITLE
make platform configurable

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -23,24 +23,25 @@ function clone(obj) {
   return newObj;
 };
 
-var CLIENT_PROPERTIES = {
-  "product": "amqplib",
-  "version": require('../package.json').version,
-  "platform": fmt('Node.JS %s', process.version),
-  "information": "http://squaremo.github.io/amqp.node",
-  "capabilities": {
-    "publisher_confirms": true,
-    "exchange_exchange_bindings": true,
-    "basic.nack": true,
-    "consumer_cancel_notify": true,
-    "connection.blocked": true,
-    "authentication_failure_close": true
-  }
-};
-
+function clientProperties(product, version) {
+  return {
+    "product": product || "amqplib",
+    "version": version || require('../package.json').version,
+    "platform": fmt('Node.JS %s', process.version),
+    "information": "http://squaremo.github.io/amqp.node",
+    "capabilities": {
+      "publisher_confirms": true,
+      "exchange_exchange_bindings": true,
+      "basic.nack": true,
+      "consumer_cancel_notify": true,
+      "connection.blocked": true,
+      "authentication_failure_close": true
+    }
+  };
+}
 
 // Parse a URL to get the options used in the opening protocol
-function openOptionsFromURL(parts) {
+function openOptionsFromURL(parts, product, version) {
   var user = 'guest', passwd = 'guest';
   if (parts.auth) {
     var auth = parts.auth.split(':');
@@ -62,7 +63,7 @@ function openOptionsFromURL(parts) {
 
   return {
     // start-ok
-    'clientProperties': CLIENT_PROPERTIES,
+    'clientProperties': clientProperties(product, version),
     'mechanism': 'PLAIN',
     'response': new Buffer(['', user, passwd].join(String.fromCharCode(0))),
     'locale': q.locale || 'en_US',
@@ -91,7 +92,7 @@ function connect(url, socketOptions, openCallback) {
   var protocol = parts.protocol;
   var noDelay = !!sockopts.noDelay;
 
-  var options = openOptionsFromURL(parts);
+  var options = openOptionsFromURL(parts, sockopts.product, sockopts.version);
   var port = parts.port || ((protocol === 'amqp:') ? 5672 : 5671);
   sockopts.host = parts.hostname;
   sockopts.port = parseInt(port);


### PR DESCRIPTION
Hi.

We use this module across multiple services and would like to use the platform string to track which services are connected to our rabbit cluster.

This PR allows you to configure `platform` by passing it as an option to connect
