### PR TITLE
Saner connection option defaults

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -70,7 +70,7 @@ function openOptionsFromURL(parts) {
     // tune-ok
     'channelMax': intOrDefault(q.channelMax, 65535),
     'frameMax': intOrDefault(q.frameMax, 131072),
-    'heartbeat': intOrDefault(q.heartbeat, 580),
+    'heartbeat': intOrDefault(q.heartbeat, 0),
 
     // open
     'virtualHost': vhost,


### PR DESCRIPTION
channelMax: 65535 channels
frameMax: 131072 bytes
heartbeat: 580s
