### PR TITLE
ConfirmChannel #publish and #sendToQueue return a promise unless a callback is provided.

### DIFF
--- a/lib/channel_model.js
+++ b/lib/channel_model.js
@@ -292,17 +292,18 @@ CM.createConfirmChannel = function() {
 var CC = ConfirmChannel.prototype;
 
 CC.publish = function(exchange, routingKey, content, options, cb) {
+  var published = C.publish.call(this, exchange, routingKey, content, options);
   if (cb) {
-    this.pushConfirmCallback(cb);
-    return C.publish.call(this, exchange, routingKey, content, options);
+    this.pushConfirmCallback(function(err) {
+      if (err) cb(err);
+      else cb(null, published);
+    });
   } else {
     var confirmed = defer();
-    var published = false;
     this.pushConfirmCallback(function(err) {
       if (err) confirmed.reject(err);
       else confirmed.resolve(published);
     });
-    published = C.publish.call(this, exchange, routingKey, content, options);
     return confirmed.promise;
   }
 };


### PR DESCRIPTION
The promise will either be rejected with an error or resolved with `false` if the channel's write buffer is 'full', and `true` otherwise. If it resolves `false`, the channel will emit a `'drain'` event at some later time.
