### PR TITLE
Actually push the promised confirmation into the await array

### DIFF
--- a/lib/callback_model.js
+++ b/lib/callback_model.js
@@ -324,6 +324,7 @@ ConfirmChannel.prototype.waitForConfirms = function(k) {
         if (err === null) confirmed.resolve();
         else confirmed.reject(err);
       };
+      await.push(confirmed.promise);
     }
   });
   return when.all(await).then(function() { k(); },


### PR DESCRIPTION
In the callback model you're not actually pushing the confirmation promises into the `await` array before calling `when.all(await)` which means that promise always gets resolved immediately because `when.all` is getting passed an empty array.
