### PR TITLE
Allow specifying connection timeout in socket options

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -101,6 +101,7 @@ function connect(url, socketOptions, openCallback) {
   var parts = URL.parse(url, true); // yes, parse the query string
   var protocol = parts.protocol;
   var noDelay = !!sockopts.noDelay;
+  var timeout = sockopts.timeout;
 
   var extraClientProperties = sockopts.clientProperties || {};
   var credentials = sockopts.credentials || credentialsFromUrl(parts);
@@ -116,6 +117,9 @@ function connect(url, socketOptions, openCallback) {
   function onConnect() {
     sockok = true;
     sock.setNoDelay(noDelay);
+    sock.setTimeout(timeout || 0, function() {
+        openCallback(new Error('connect ETIMEDOUT'));
+    });
     var c = new Connection(sock);
     c.open(fields, function(err, ok) {
       if (err === null) openCallback(null, c);

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -117,9 +117,13 @@ function connect(url, socketOptions, openCallback) {
   function onConnect() {
     sockok = true;
     sock.setNoDelay(noDelay);
-    sock.setTimeout(timeout || 0, function() {
-        openCallback(new Error('connect ETIMEDOUT'));
-    });
+
+    if (typeof timeout !== 'undefined') {
+        sock.setTimeout(timeout, function() {
+            openCallback(new Error('connect ETIMEDOUT'));
+        });
+    }
+
     var c = new Connection(sock);
     c.open(fields, function(err, ok) {
       if (err === null) openCallback(null, c);

--- a/test/connect.js
+++ b/test/connect.js
@@ -3,6 +3,7 @@
 var connect = require('../lib/connect').connect;
 var assert = require('assert');
 var util = require('./util');
+var net = require('net');
 var fail = util.fail, succeed = util.succeed,
     kCallback = util.kCallback;
 
@@ -51,6 +52,16 @@ suite("Connect API", function() {
     };
     connect(URL, {credentials: creds},
             kCallback(fail(done), succeed(done)));
+  });
+
+  test("with a given connection timeout", function(done) {
+    var timeoutServer = net.createServer(function() {}).listen(31991);
+
+    connect('amqp://localhost:31991', {timeout: 50}, function(err, val) {
+        timeoutServer.close();
+        if (val) done(new Error('Expected connection timeout, did not'));
+        else done();
+    });
   });
 
 });


### PR DESCRIPTION
Since `connect()` does not return the socket instance, there is currently no easy way to set the connection timeout. This PR adds a `timeout` option to the socket options passed to `connect()`, and automatically sets it on the socket when connecting. If a timeout is reached, it will trigger the connect callback with an error.

This should solve #88 .