### PR TITLE
fix connecting on uris with trailing slash and no vhost

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -47,7 +47,7 @@ var CLIENT_PROPERTIES = {
 function openFrames(parts, credentials, extraClientProperties) {
 
   var vhost = parts.pathname;
-  if (!vhost)
+  if (!vhost || vhost === '/')
     vhost = '/';
   else
     vhost = QS.unescape(vhost.substr(1));

--- a/test/connect.js
+++ b/test/connect.js
@@ -53,4 +53,8 @@ suite("Connect API", function() {
             kCallback(fail(done), succeed(done)));
   });
 
+  test("uri with trailing slash", function (done) {
+    connect(URL + '/', {}, kCallback(succeed(done), fail(done)));
+  });
+
 });


### PR DESCRIPTION
This PR fixes the case where this would fail:

```js
amqp.connect('amqp://127.0.0.1:5672/')
```

but this would succeed:
```js
amqp.connect('amqp://127.0.0.1:5672');
```

The trailing slash in the first example becomes an empty vhost as determined in connect.js: https://github.com/hopkinsth/amqp.node/blob/a972f63edf9321c901cf016b3a6f642d72d54380/lib/connect.js#L53