### PR TITLE
Add keep-alive and timeout options (thanks @rexxar)

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -85,7 +85,7 @@ function credentialsFromUrl(parts) {
   if (parts.auth) {
     var auth = parts.auth.split(':');
     user = auth[0];
-    passwd = auth[1];    
+    passwd = auth[1];
   }
   return credentials.plain(user, passwd);
 }
@@ -101,7 +101,11 @@ function connect(url, socketOptions, openCallback) {
   var parts = URL.parse(url, true); // yes, parse the query string
   var protocol = parts.protocol;
   var noDelay = !!sockopts.noDelay;
-  var timeout = sockopts.timeout;
+  // We should default to true as this nicely complements the heartbeat
+  var keepAlive = !!sockopts.keepAlive || true;
+  // 0 is default for node
+  var keepAliveDelay = sockopts.keepAliveDelay || 0;
+  var timeout = sockopts.timeout || 0;
 
   var extraClientProperties = sockopts.clientProperties || {};
   var credentials = sockopts.credentials || credentialsFromUrl(parts);
@@ -117,9 +121,9 @@ function connect(url, socketOptions, openCallback) {
   function onConnect() {
     sockok = true;
     sock.setNoDelay(noDelay);
-    sock.setTimeout(timeout || 0, function() {
-        openCallback(new Error('connect ETIMEDOUT'));
-    });
+    sock.setTimeout(timeout, openCallback.bind(null, new Error('ETIMEDOUT')));
+    sock.setKeepAlive(keepAlive, keepAliveDelay);
+
     var c = new Connection(sock);
     c.open(fields, function(err, ok) {
       if (err === null) openCallback(null, c);

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -102,7 +102,7 @@ function connect(url, socketOptions, openCallback) {
   var protocol = parts.protocol;
   var noDelay = !!sockopts.noDelay;
   // We should default to true as this nicely complements the heartbeat
-  var keepAlive = !!sockopts.keepAlive || true;
+  var keepAlive = sockopts.keepAlive === false ? false : true;
   // 0 is default for node
   var keepAliveDelay = sockopts.keepAliveDelay || 0;
   var timeout = sockopts.timeout || 0;

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -101,6 +101,7 @@ function connect(url, socketOptions, openCallback) {
   var parts = URL.parse(url, true); // yes, parse the query string
   var protocol = parts.protocol;
   var noDelay = !!sockopts.noDelay;
+  var timeout = sockopts.timeout;
 
   var extraClientProperties = sockopts.clientProperties || {};
   var credentials = sockopts.credentials || credentialsFromUrl(parts);
@@ -116,6 +117,9 @@ function connect(url, socketOptions, openCallback) {
   function onConnect() {
     sockok = true;
     sock.setNoDelay(noDelay);
+    sock.setTimeout(timeout || 0, function() {
+        openCallback(new Error('connect ETIMEDOUT'));
+    });
     var c = new Connection(sock);
     c.open(fields, function(err, ok) {
       if (err === null) openCallback(null, c);

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -260,7 +260,9 @@ C.open = function(allFields, openCallback0) {
   function succeed(ok) {
     self.stream.removeListener('end', endWhileOpening);
     self.stream.removeListener('error', endWhileOpening);
-    self.stream.on('error', self.onSocketError.bind(self));    
+    self.stream.removeListener('timeout', endWhileOpening);
+    self.stream.on('error', self.onSocketError.bind(self));
+    self.stream.on('timeout', self.onSocketTimeout.bind(self));
     self.stream.on('end', self.onSocketError.bind(
       self, new Error('Unexpected close')));
     self.on('frameError', self.onSocketError.bind(self));
@@ -336,6 +338,12 @@ C.closeBecause = function(reason, code, k) {
 C.closeWithError = function(reason, code, error) {
   this.emit('error', error);
   this.closeBecause(reason, code);
+};
+
+C.onSocketTimeout = function () {
+  self.emit('error', new Error('TCP Timeout'));
+  var s = stackCapture('TCP Timeout');
+  self.toClosed(s);
 };
 
 C.onSocketError = function(err) {
@@ -542,7 +550,7 @@ C.sendMessage = function(channel,
     var all = new Buffer(allLen);
     var offset = mframe.copy(all, 0);
     offset += pframe.copy(all, offset);
-    
+
     if (bodyLen > 0)
       makeBodyFrame(channel, content).copy(all, offset);
     return buffer.write(all);
@@ -590,7 +598,7 @@ var decodeFrame = frame.decodeFrame;
 C.recvFrame = function() {
   // %%% identifying invariants might help here?
   var frame = parseFrame(this.rest, this.frameMax);
- 
+
   if (!frame) {
     var incoming = this.stream.read();
     if (incoming === null) {

--- a/test/connect.js
+++ b/test/connect.js
@@ -3,6 +3,7 @@
 var connect = require('../lib/connect').connect;
 var assert = require('assert');
 var util = require('./util');
+var net = require('net');
 var fail = util.fail, succeed = util.succeed,
     kCallback = util.kCallback;
 
@@ -51,6 +52,16 @@ suite("Connect API", function() {
     };
     connect(URL, {credentials: creds},
             kCallback(fail(done), succeed(done)));
+  });
+
+  test("with a given connection timeout", function(done) {
+    var timeoutServer = net.createServer(function() {}).listen(31991);
+
+    connect('amqp://localhost:31991', {timeout: 50}, function(err, val) {
+        timeoutServer.close();
+        if (val) done(new Error('Expected connection timeout, did not'));
+        else done();
+    });
   });
 
 });


### PR DESCRIPTION
When implementing keep-alive support I just pulled in the work from @rexxar on timeouts as i slightly refactored it to handle timeout events that could possibly happen after connect (which I have not seen but was going for the side of safety). @squaremo let me know your thoughts as I think having keep-alive support is a nice complement to the heartbeat functionality you have implemented.