### PR TITLE
node: ">=0.8 <0.13 || ^1"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,13 @@ node_js:
    - "0.12"
    - "iojs-v1.0"
    - "iojs-v1.1"
+   - "iojs-v1.2"
+   - "iojs-v1.3"
+   - "iojs-v1.4"
+   - "iojs-v1.5"
+   - "iojs-v1.6"
+   - "iojs-v1"
+   - "iojs"
 
 services:
    - rabbitmq

--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
   "name": "amqplib",
   "homepage": "http://squaremo.github.io/amqp.node/",
   "main": "./channel_api.js",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "An AMQP 0-9-1 (e.g., RabbitMQ) library and client.",
   "repository": {
     "type": "git",
     "url": "https://github.com/squaremo/amqp.node.git"
   },
   "engines": {
-    "node": "0.8 || 0.9 || 0.10 || 0.11 || 0.12 || 1.0 || 1.1"
+    "node": ">=0.8 <0.13 || ^1"
   },
   "dependencies": {
     "bitsyntax": "~0.0.4",


### PR DESCRIPTION
@squaremo - Here at Lanetix we are using amqplib with iojs v1 - v1.6.2 and it works well.
Since all iojs-v1.x.x should be backward compatible, there is no reason to specify a specific iojs version in the package.json file.
This change will remove the warning we see when we install amqplib using npm with the latest versions of iojs (ex: 1.6.2).

Thanks,
-Oron