### PR TITLE
add support for passing connection parameters as an object

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -108,12 +108,17 @@ function connect(url, socketOptions, openCallback) {
 	protocol = (url.protocol || 'amqp') + ':';
 	sockopts.host = url.hostname;
 	sockopts.port = url.port || ((protocol === 'amqp:') ? 5672 : 5671);
+	
+	var user, pass;	
     if (!url.username) {
-      url.username = 'guest';
-      url.password = url.password || 'guest';
-    }
+      user = 'guest';
+      pass = url.password || 'guest';
+    } else {
+      user = url.username;
+      pass = url.password;
+	}
 
-    fields = openFrames(url.vhost, null, sockopts.credentials || credentials.plain(url.username, url.password), extraClientProperties);
+    fields = openFrames(url.vhost, null, sockopts.credentials || credentials.plain(user, pass), extraClientProperties);
   } else {
 	var parts = URL.parse(url, true); // yes, parse the query string
 	protocol = parts.protocol;

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -42,17 +42,14 @@ var CLIENT_PROPERTIES = {
   }
 };
 
-
 // Construct the main frames used in the opening handshake
-function openFrames(parts, credentials, extraClientProperties) {
-
-  var vhost = parts.pathname;
+function openFrames(vhost, query, credentials, extraClientProperties) {
   if (!vhost)
     vhost = '/';
   else
-    vhost = QS.unescape(vhost.substr(1));
+    vhost = QS.unescape(vhost);
 
-  var q = parts.query || {};
+  var query = query || {};
 
   function intOrDefault(val, def) {
     return (val === undefined) ? def : parseInt(val);
@@ -65,12 +62,12 @@ function openFrames(parts, credentials, extraClientProperties) {
     'clientProperties': copyInto(extraClientProperties, clientProperties),
     'mechanism': credentials.mechanism,
     'response': credentials.response(),
-    'locale': q.locale || 'en_US',
+    'locale': query.locale || 'en_US',
 
     // tune-ok
-    'channelMax': intOrDefault(q.channelMax, 0),
-    'frameMax': intOrDefault(q.frameMax, 0x1000),
-    'heartbeat': intOrDefault(q.heartbeat, 0),
+    'channelMax': intOrDefault(query.channelMax, 0),
+    'frameMax': intOrDefault(query.frameMax, 0x1000),
+    'heartbeat': intOrDefault(query.heartbeat, 0),
 
     // open
     'virtualHost': vhost,
@@ -97,9 +94,7 @@ function connect(url, socketOptions, openCallback) {
   // than using `Object.create()`.
   var sockopts = clone(socketOptions || {});
   url = url || 'amqp://localhost';
-
-  var parts = URL.parse(url, true); // yes, parse the query string
-  var protocol = parts.protocol;
+  
   var noDelay = !!sockopts.noDelay;
   var timeout = sockopts.timeout;
   var keepAlive = !!sockopts.keepAlive;
@@ -107,12 +102,26 @@ function connect(url, socketOptions, openCallback) {
   var keepAliveDelay = sockopts.keepAliveDelay || 0;
 
   var extraClientProperties = sockopts.clientProperties || {};
-  var credentials = sockopts.credentials || credentialsFromUrl(parts);
+  
+  var protocol, fields;
+  if (typeof url === 'object') {
+	protocol = (url.protocol || 'amqp') + ':';
+	sockopts.host = url.hostname;
+	sockopts.port = url.port || ((protocol === 'amqp:') ? 5672 : 5671);
+    if (!url.username) {
+      url.username = 'guest';
+      url.password = url.password || 'guest';
+    }
 
-  var fields = openFrames(parts, credentials, extraClientProperties);
-  var port = parts.port || ((protocol === 'amqp:') ? 5672 : 5671);
-  sockopts.host = parts.hostname;
-  sockopts.port = parseInt(port);
+    fields = openFrames(url.vhost, null, sockopts.credentials || credentials.plain(url.username, url.password), extraClientProperties);
+  } else {
+	var parts = URL.parse(url, true); // yes, parse the query string
+	protocol = parts.protocol;
+	sockopts.host = parts.hostname;
+	sockopts.port = parseInt(parts.port) || ((protocol === 'amqp:') ? 5672 : 5671);
+    var vhost = parts.pathname ? parts.pathname.substr(1) : null;
+	fields = openFrames(vhost, parts.query, sockopts.credentials || credentialsFromUrl(parts), extraClientProperties);
+  }
 
   var sockok = false;
   var sock;

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -108,24 +108,24 @@ function connect(url, socketOptions, openCallback) {
 	protocol = (url.protocol || 'amqp') + ':';
 	sockopts.host = url.hostname;
 	sockopts.port = url.port || ((protocol === 'amqp:') ? 5672 : 5671);
-	
-	var user, pass;	
+    
+    var user, pass;
     if (!url.username) {
       user = 'guest';
       pass = url.password || 'guest';
     } else {
       user = url.username;
       pass = url.password;
-	}
+    }
 
     fields = openFrames(url.vhost, null, sockopts.credentials || credentials.plain(user, pass), extraClientProperties);
   } else {
-	var parts = URL.parse(url, true); // yes, parse the query string
-	protocol = parts.protocol;
-	sockopts.host = parts.hostname;
-	sockopts.port = parseInt(parts.port) || ((protocol === 'amqp:') ? 5672 : 5671);
+    var parts = URL.parse(url, true); // yes, parse the query string
+    protocol = parts.protocol;
+    sockopts.host = parts.hostname;
+    sockopts.port = parseInt(parts.port) || ((protocol === 'amqp:') ? 5672 : 5671);
     var vhost = parts.pathname ? parts.pathname.substr(1) : null;
-	fields = openFrames(vhost, parts.query, sockopts.credentials || credentialsFromUrl(parts), extraClientProperties);
+    fields = openFrames(vhost, parts.query, sockopts.credentials || credentialsFromUrl(parts), extraClientProperties);
   }
 
   var sockok = false;


### PR DESCRIPTION
The built in url.parse() does not properly handle encoded variables in the username or password. Consequently, some username and/or passwords can not be based to amqplib as a URL. For reference, see: https://github.com/joyent/node/issues/25353

So, I updated connect() to support passing connection parameters as an object:
```javascript
var url = {
    protocol: 'amqp', //amqp or amqps
    username: 'someone',
    password: 'secret',
    hostname: '127.0.0.1',
    port: 5672,
    vhost: 'name'
}
connect([url, [socketOptions]], function(err, conn) {...})
```

