### PR TITLE
add a new error on net or tls connect timeout

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -161,7 +161,12 @@ function connect(url, socketOptions, openCallback) {
   else {
     throw new Error("Expected amqp: or amqps: as the protocol; got " + protocol);
   }
-
+  if (timeout) {
+    sock.setTimeout(
+      timeout, function(){
+        this.emit('error', new Error('connect ETIMEDOUT'))
+      });
+  }
   sock.once('error', function(err) {
     if (!sockok) openCallback(err);
   });


### PR DESCRIPTION
I don't know if your error throwing is still used with my changes, i don't think so. But without it, if I tryed to connect on an unused IP, I just ran to infinite async wait, no error was called. 