### PR TITLE
Provided a tutorial for RabbitMq priority queue implementation

### DIFF
--- a/examples/tutorials/README.md
+++ b/examples/tutorials/README.md
@@ -80,6 +80,14 @@ and routing replies back to clients.
  * [rpc_server.js](rpc_server.js)
  * [rpc_client.js](rpc_client.js)
 
+## [Tutorial seven: Priority Queue][tute-seven]
+
+RabbitMQ has priority queue implementation in the core as of version 3.5.0.
+Using RabbitMQ as a priority queue, showing how to set maximum priority value supported by the queue and setting priority of each message pushed to the queue. In case of messages having equal value of priority, they are consumed in FIFO order.
+
+ * [send_priority_queue.js](callback_api/send_priority_queue.js)
+ * [receive_priority_queue.js](callback_api/receive_priority_queue.js)
+
 I depart slightly from the original tutorial code, which I think has
 some needless object-orientation (in the Python code; you don't get a
 choice about needless object-orientation in Java).
@@ -91,3 +99,4 @@ choice about needless object-orientation in Java).
 [tute-four]: http://www.rabbitmq.com/tutorials/tutorial-four-python.html
 [tute-five]: http://www.rabbitmq.com/tutorials/tutorial-five-python.html
 [tute-six]: http://www.rabbitmq.com/tutorials/tutorial-six-python.html
+[tute-seven]: https://www.rabbitmq.com/priority.html

--- a/examples/tutorials/callback_api/receive_priority_queue.js
+++ b/examples/tutorials/callback_api/receive_priority_queue.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+var amqp = require('amqplib/callback_api');
+
+function bail(err, conn) {
+  console.error(err);
+  if (conn) conn.close(function() { process.exit(1); });
+}
+
+function on_connect(err, conn) {
+  if (err !== null) return bail(err);
+  process.once('SIGINT', function() { conn.close(); });
+  
+  var q = 'hello';
+
+  function on_channel_open(err, ch) {
+    ch.assertQueue(q, {durable: false, maxPriority: 10}, function(err, ok) {
+      if (err !== null) return bail(err, conn);
+      ch.consume(q, function(msg) { // message callback
+        console.log(" [x] Received '%s'", msg.content.toString());
+      }, {noAck: true}, function(_consumeOk) { // consume callback
+        console.log(' [*] Waiting for messages. To exit press CTRL+C');
+      });
+    });
+  }
+
+  conn.createChannel(on_channel_open);
+}
+
+amqp.connect(on_connect);

--- a/examples/tutorials/callback_api/send_priority_queue.js
+++ b/examples/tutorials/callback_api/send_priority_queue.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+var amqp = require('amqplib/callback_api');
+
+function bail(err, conn) {
+  console.error(err);
+  if (conn) conn.close(function() { process.exit(1); });
+}
+
+function on_connect(err, conn) {
+  if (err !== null) return bail(err);
+
+  var q = 'hello';
+  var message = '';
+  var priorityValue = 0;
+
+  function on_channel_open(err, ch) {
+    if (err !== null) return bail(err, conn);
+    ch.assertQueue(q, {durable: false, maxPriority: 10}, function(err, ok) {
+      if (err !== null) return bail(err, conn);
+
+      for(var index=1; index<=50; index++) {
+        priorityValue = Math.floor((Math.random() * 10));
+        // index refers to message number. Lower is the index value, earlier is the message pushed into the queue.
+        message = 'Message index = ' + index + ' and Priority Value = ' + priorityValue;
+        ch.sendToQueue(q, new Buffer(message), {priority: priorityValue});
+        console.log(" [x] Sent '%s'", message);
+      }
+      ch.close(function() { conn.close(); });
+    });
+  }
+
+  conn.createChannel(on_channel_open);
+}
+
+amqp.connect(on_connect);


### PR DESCRIPTION
I have observed RabbitMq tutorials for different client's are quite consistent i.e., exactly same tutorials are available for all client's. Updating/adding tutorial of one of the client possibly requires porting the exact same tutorial for all other client's

Therefore, I would be happy to issue following PR's step wise as follow-up commits:
1. Porting the same tutorial for [Javascript (with Node and amqp-node)](https://github.com/squaremo/amqp.node/tree/master/examples/tutorials) (using promises/futures)
2. Porting the same tutorial for all [RabbitMq clients](https://github.com/rabbitmq/rabbitmq-tutorials) with a separate PR for each client in step-wise order.
3. If feasible and applicable, porting the tutorial demonstration over official [RabbitMq website](https://www.rabbitmq.com/getstarted.html) in step-wise order for supported client's as such the [website source](https://github.com/rabbitmq/rabbitmq-website/) is open.

Please correct me if above idea(s) doesn't really make sense or is(are) not applicable.
