### PR TITLE
Add handler for BasicCancelOk message to fix no null message on cancelled consume

### DIFF
--- a/lib/channel.js
+++ b/lib/channel.js
@@ -390,6 +390,8 @@ C.accept = function(f) {
     return this.emit('nack', f.fields);
   case defs.BasicCancel:
     // The broker can send this if e.g., the queue is deleted.
+  case defs.BasicCancelOk:
+    // The broker will send this when channel is cancelled
     return this.emit('cancel', f.fields);
 
   case defs.ChannelClose:


### PR DESCRIPTION
Fixes issue #200 