### PR TITLE
Split open frame options

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -58,21 +58,22 @@ function openFrames(vhost, query, credentials, extraClientProperties) {
   var clientProperties = Object.create(CLIENT_PROPERTIES);
 
   return {
-    // start-ok
-    'clientProperties': copyInto(extraClientProperties, clientProperties),
-    'mechanism': credentials.mechanism,
-    'response': credentials.response(),
-    'locale': query.locale || 'en_US',
-
-    // tune-ok
-    'channelMax': intOrDefault(query.channelMax, 0),
-    'frameMax': intOrDefault(query.frameMax, 0x1000),
-    'heartbeat': intOrDefault(query.heartbeat, 0),
-
-    // open
-    'virtualHost': vhost,
-    'capabilities': '',
-    'insist': 0
+    startOk: {
+      'clientProperties': copyInto(extraClientProperties, clientProperties),
+      'mechanism': credentials.mechanism,
+      'response': credentials.response(),
+      'locale': query.locale || 'en_US',
+    },
+    tuneOk: {
+      'channelMax': intOrDefault(query.channelMax, 0),
+      'frameMax': intOrDefault(query.frameMax, 0x1000),
+      'heartbeat': intOrDefault(query.heartbeat, 0),
+    },
+    open: {
+      'virtualHost': vhost,
+      'capabilities': '',
+      'insist': 0
+    }
   };
 }
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -200,7 +200,7 @@ C.open = function(frameOptions, openCallback0) {
     var mechanisms = start.fields.mechanisms.toString().split(' ');
     if (mechanisms.indexOf(frameOptions.startOk.mechanism) < 0) {
       bail(new Error(fmt('SASL mechanism %s is not provided by the server',
-                         allFields.mechanism)));
+                         frameOptions.startOk.mechanism)));
       return;
     }
     send(defs.ConnectionStartOk, frameOptions.startOk);

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -141,12 +141,11 @@ back a `secure`, it'll just send `tune` after the `start-ok`.
 
 */
 
-C.open = function(allFields, openCallback0) {
+C.open = function(frameOptions, openCallback0) {
   var self = this;
   var openCallback = openCallback0 || function() {};
 
-  // This is where we'll put our negotiated values
-  var tunedOptions = Object.create(allFields);
+  var tunedOptions = Object.create(frameOptions.tuneOk);
 
   function await(k) {
     self.step(function(err, frame) {
@@ -175,10 +174,10 @@ C.open = function(allFields, openCallback0) {
     openCallback(err);
   }
 
-  function send(Method) {
+  function send(Method, options) {
     // This can throw an exception if there's some problem with the
     // options; e.g., something is a string instead of a number.
-    try { self.sendMethod(0, Method, tunedOptions); }
+    try { self.sendMethod(0, Method, options); }
     catch (err) { bail(err); }
   }
 
@@ -199,12 +198,12 @@ C.open = function(allFields, openCallback0) {
 
   function onStart(start) {
     var mechanisms = start.fields.mechanisms.toString().split(' ');
-    if (mechanisms.indexOf(allFields.mechanism) < 0) {
+    if (mechanisms.indexOf(frameOptions.startOk.mechanism) < 0) {
       bail(new Error(fmt('SASL mechanism %s is not provided by the server',
                          allFields.mechanism)));
       return;
     }
-    send(defs.ConnectionStartOk);
+    send(defs.ConnectionStartOk, frameOptions.startOk);
     await(afterStartOk);
   }
 
@@ -220,14 +219,15 @@ C.open = function(allFields, openCallback0) {
       break;
     case defs.ConnectionTune:
       var fields = reply.fields;
+      var options = frameOptions.tuneOk;
       tunedOptions.frameMax =
-        negotiate(fields.frameMax, allFields.frameMax);
+        negotiate(fields.frameMax, options.frameMax);
       tunedOptions.channelMax =
-        negotiate(fields.channelMax, allFields.channelMax);
+        negotiate(fields.channelMax, options.channelMax);
       tunedOptions.heartbeat =
-        negotiate(fields.heartbeat, allFields.heartbeat);
-      send(defs.ConnectionTuneOk);
-      send(defs.ConnectionOpen);
+        negotiate(fields.heartbeat, options.heartbeat);
+      send(defs.ConnectionTuneOk, tunedOptions);
+      send(defs.ConnectionOpen, frameOptions.open);
       expect(defs.ConnectionOpenOk, onOpenOk);
       break;
     default:

--- a/test/connection.js
+++ b/test/connection.js
@@ -13,21 +13,22 @@ var kCallback = util.kCallback;
 var LOG_ERRORS = process.env.LOG_ERRORS;
 
 var OPEN_OPTS = {
-  // start-ok
-  'clientProperties': {},
-  'mechanism': 'PLAIN',
-  'response': new Buffer(['', 'guest', 'guest'].join(String.fromCharCode(0))),
-  'locale': 'en_US',
-  
-  // tune-ok
-  'channelMax': 0,
-  'frameMax': 0,
-  'heartbeat': 0,
-  
-  // open
-  'virtualHost': '/',
-  'capabilities': '',
-  'insist': 0
+  startOk: {
+    'clientProperties': {},
+    'mechanism': 'PLAIN',
+    'response': new Buffer(['', 'guest', 'guest'].join(String.fromCharCode(0))),
+    'locale': 'en_US'
+  },
+  tuneOk: {
+    'channelMax': 0,
+    'frameMax': 0,
+    'heartbeat': 0
+  },
+  open: {
+    'virtualHost': '/',
+    'capabilities': '',
+    'insist': 0
+  }
 };
 module.exports.OPEN_OPTS = OPEN_OPTS;
 
@@ -85,7 +86,7 @@ suite("Connection errors", function() {
     pair.server.on('readable', function() {
       pair.server.end();
     });
-    conn.open({}, kCallback(fail(done), succeed(done)));
+    conn.open(OPEN_OPTS, kCallback(fail(done), succeed(done)));
   });
 
   test("bad frame during open", function(done) {
@@ -94,7 +95,7 @@ suite("Connection errors", function() {
     ss.server.on('readable', function() {
       ss.server.write(new Buffer([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]));
     });
-    conn.open({}, kCallback(fail(done), succeed(done)));
+    conn.open(OPEN_OPTS, kCallback(fail(done), succeed(done)));
   });
 
 });
@@ -351,7 +352,7 @@ test("send heartbeat after open", connectionTest(
   function(c, done) {
     completes(function() {
       var opts = Object.create(OPEN_OPTS);
-      opts.heartbeat = 1;
+      opts.tuneOk.heartbeat = 1;
       // Don't leave the error waiting to happen for the next test, this
       // confuses mocha awfully
       c.on('error', function() {});
@@ -377,7 +378,7 @@ test("send heartbeat after open", connectionTest(
 test("detect lack of heartbeats", connectionTest(
   function(c, done) {
     var opts = Object.create(OPEN_OPTS);
-    opts.heartbeat = 1;
+    opts.tuneOk.heartbeat = 1;
     c.on('error', succeed(done));
     c.open(opts);
   },


### PR DESCRIPTION
Open frame options are now clearly separated. Makes it easier to read and we'll only send the relevant frame options during the handshake.

(While debugging a connection issue it caught me that I can't properly see frame options because of not-enumerable properties created by `Object.create`. Then I realised all frame options are sent all the time.)