### PR TITLE
Keep starting slash in vhost name for ConnectionOpen frame

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -124,7 +124,7 @@ function connect(url, socketOptions, openCallback) {
     protocol = parts.protocol;
     sockopts.host = parts.hostname;
     sockopts.port = parseInt(parts.port) || ((protocol === 'amqp:') ? 5672 : 5671);
-    var vhost = parts.pathname ? parts.pathname.substr(1) : null;
+    var vhost = parts.pathname;
     fields = openFrames(vhost, parts.query, sockopts.credentials || credentialsFromUrl(parts), extraClientProperties);
   }
 


### PR DESCRIPTION
I keep getting connection closed on ConnectionOpen while setting up an amqps connection and keeping the trailing slash fixes it. ([postwait/node-amqp](https://github.com/postwait/node-amqp) does the same thing, that's where I got the idea from)