### PR TITLE
test latest node. See nvm "node" alias

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,6 @@ services:
    - rabbitmq
 
 before_install:
-   - node --version | grep  -v 'v5' && npm install -g npm@2
+   - node --version | (grep  -v 'v5' && npm install -g npm@2) || true
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,13 @@ node_js:
    - "iojs-v2"
    - "iojs-v3"
    - "4.0"
+   - "node"
+
 
 services:
    - rabbitmq
 
 before_install:
-  - npm install -g npm@2
+   - node --version | grep  -v 'v5' && npm install -g npm@2
 
 sudo: false


### PR DESCRIPTION
Travis uses nvm to install node. By adding the "node" option to `node_js` configuration you enforce your test to run on latest node version. 

I updated the `before_install` hook to ensure that npm v2 is installed unless current travis VM is running node V5 because node V5 comes with npm v3.