### PR TITLE
Better Promise Example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,28 +83,24 @@ var open = require('amqplib').connect('amqp://localhost');
 
 // Publisher
 open.then(function(conn) {
-  var ok = conn.createChannel();
-  ok = ok.then(function(ch) {
-    ch.assertQueue(q);
-    ch.sendToQueue(q, new Buffer('something to do'));
-  });
-  return ok;
-}).then(null, console.warn);
+  return conn.createChannel();
+}).then(function(ch) {
+  ch.assertQueue(q);
+  ch.sendToQueue(q, new Buffer('something to do'));
+}).catch(console.warn);
 
 // Consumer
 open.then(function(conn) {
-  var ok = conn.createChannel();
-  ok = ok.then(function(ch) {
-    ch.assertQueue(q);
-    ch.consume(q, function(msg) {
-      if (msg !== null) {
-        console.log(msg.content.toString());
-        ch.ack(msg);
-      }
-    });
+  return conn.createChannel();
+}).then(function(ch) {
+  ch.assertQueue(q);
+  ch.consume(q, function(msg) {
+    if (msg !== null) {
+      console.log(msg.content.toString());
+      ch.ack(msg);
+    }
   });
-  return ok;
-}).then(null, console.warn);
+}).catch(console.warn);
 ```
 
 ## Running tests

--- a/README.md
+++ b/README.md
@@ -85,20 +85,22 @@ var open = require('amqplib').connect('amqp://localhost');
 open.then(function(conn) {
   return conn.createChannel();
 }).then(function(ch) {
-  ch.assertQueue(q);
-  ch.sendToQueue(q, new Buffer('something to do'));
+  return ch.assertQueue(q).then(function(ok) {
+    return ch.sendToQueue(q, new Buffer('something to do'));
+  });
 }).catch(console.warn);
 
 // Consumer
 open.then(function(conn) {
   return conn.createChannel();
 }).then(function(ch) {
-  ch.assertQueue(q);
-  ch.consume(q, function(msg) {
-    if (msg !== null) {
-      console.log(msg.content.toString());
-      ch.ack(msg);
-    }
+  return ch.assertQueue(q).then(function(ok) {
+    return ch.consume(q, function(msg) {
+      if (msg !== null) {
+        console.log(msg.content.toString());
+        ch.ack(msg);
+      }
+    });
   });
 }).catch(console.warn);
 ```


### PR DESCRIPTION
The original Promise API example in README has a few exhibition of what's now considered to be [Promise bad practices](https://pouchdb.com/2015/05/18/we-have-a-problem-with-promises.html), namely:

1. Not utilizing the otherwise elegant feature of "chained-then" pattern.
2. (Also related 1.) Not utilizing `catch` and instead utilizing somewhat inferior `rejectHandler` interface.

In the future, it'll be a great user-experience boost if the `callback_api` can be "merged" with the promise API so that if no callback is given, it automatically returns a promise, like many other libraries do.