### PR TITLE
Updates the url that links to rabbit_heartbeat.erl

### DIFF
--- a/lib/heartbeat.js
+++ b/lib/heartbeat.js
@@ -40,7 +40,7 @@
 //    at least twice before sending another)
 //
 // This design is based largely on RabbitMQ's heartbeating:
-// https://github.com/rabbitmq/rabbitmq-server/blob/master/src/rabbit_heartbeat.erl
+// https://github.com/rabbitmq/rabbitmq-common/blob/master/src/rabbit_heartbeat.erl
 
 // %% Yes, I could apply the same 'actually passage of time' thing to
 // %% send as well as to recv.


### PR DESCRIPTION
I know this is not pressing but when I was going through this project
trying to learn more about the heartbeat part of RabbitMQ I noticed
that this link was no longer valid as that part has been moved out into
the rabbitmq-commom package.

Todd Pickell @tapickell <tapickell@gmail.com>