### PR TITLE
Fix bad this reference on Channel#closeBecause

### DIFF
--- a/lib/channel_model.js
+++ b/lib/channel_model.js
@@ -73,8 +73,9 @@ C.open = function() {
 };
 
 C.close = function() {
+  var self = this;
   return Promise.fromCallback(function(cb) {
-    return this.closeBecause("Goodbye", defs.constants.REPLY_SUCCESS,
+    return self.closeBecause("Goodbye", defs.constants.REPLY_SUCCESS,
                     cb);
   });
 };

--- a/test/channel_api.js
+++ b/test/channel_api.js
@@ -40,7 +40,7 @@ function channel_test(chmethod, name, chfun) {
       c[chmethod]().then(ignoreErrors).then(chfun)
         .then(succeed(done), fail(done))
       // close the connection regardless of what happens with the test
-        .then(function() {c.close();});
+        .finally(function() {c.close();});
     });
   });
 }
@@ -507,6 +507,12 @@ chtest("prefetch", function(ch) {
     .then(function(c) {
       return assert.equal(2, c);
     });
+});
+
+chtest('close', function(ch) {
+  // Resolving promise guarantees
+  // channel is closed
+  return ch.close();
 });
 
 });


### PR DESCRIPTION
Fixes #297. Also adds a unit test to cover `Channel#close()`.