### PR TITLE
exposes IllegalOperationError to public API

### DIFF
--- a/callback_api.js
+++ b/callback_api.js
@@ -19,3 +19,4 @@ function connect(url, options, cb) {
 
 module.exports.connect = connect;
 module.exports.credentials = require('./lib/credentials');
+module.exports.IllegalOperationError = require('./lib/error').IllegalOperationError;

--- a/channel_api.js
+++ b/channel_api.js
@@ -13,3 +13,4 @@ function connect(url, connOptions) {
 
 module.exports.connect = connect;
 module.exports.credentials = require('./lib/credentials');
+module.exports.IllegalOperationError = require('./lib/error').IllegalOperationError;


### PR DESCRIPTION
#299 

```javascript
const amqp = require('amqplib');
const IllegalOperationError = amqp.IllegalOperationError;
```
or
```javascript
const amqp = require('amqplib/callback_api');
const IllegalOperationError = amqp.IllegalOperationError;
```