### PR TITLE
Specify heartbeat with object configuration

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -118,7 +118,14 @@ function connect(url, socketOptions, openCallback) {
       pass = url.password;
     }
 
-    fields = openFrames(url.vhost, null, sockopts.credentials || credentials.plain(user, pass), extraClientProperties);
+    var config = {
+      locale: url.locale,
+      channelMax: url.channelMax,
+      frameMax: url.frameMax,
+      heartbeat: url.heartbeat,
+    };
+
+    fields = openFrames(url.vhost, config, sockopts.credentials || credentials.plain(user, pass), extraClientProperties);
   } else {
     var parts = URL.parse(url, true); // yes, parse the query string
     protocol = parts.protocol;

--- a/test/connect.js
+++ b/test/connect.js
@@ -5,7 +5,8 @@ var assert = require('assert');
 var util = require('./util');
 var net = require('net');
 var fail = util.fail, succeed = util.succeed,
-    kCallback = util.kCallback;
+    kCallback = util.kCallback,
+    succeedIfAttributeEquals = util.succeedIfAttributeEquals;
 
 var URL = process.env.URL || 'amqp://localhost';
 
@@ -15,7 +16,7 @@ suite("Connect API", function() {
     connect('amqp://localhost:23450', {},
             kCallback(fail(done), succeed(done)));
   });
-  
+
   // %% this ought to fail the promise, rather than throwing an error
   test("bad URL", function() {
     assert.throws(function() {
@@ -31,6 +32,22 @@ suite("Connect API", function() {
     parts.query = q;
     var u = url.format(parts);
     connect(u, {}, kCallback(fail(done), succeed(done)));
+  });
+
+  test("using custom heartbeat option", function(done) {
+    var url = require('url');
+    var parts = url.parse(URL, true);
+    var config = parts.query || {};
+    config.heartbeat = 20;
+    connect(config, {}, kCallback(succeedIfAttributeEquals('heartbeat', 20, done), fail(done)));
+  });
+
+  test("wrongly typed heartbeat option", function(done) {
+    var url = require('url');
+    var parts = url.parse(URL, true);
+    var config = parts.query || {};
+    config.heartbeat = 'NOT A NUMBER';
+    connect(config, {}, kCallback(fail(done), succeed(done)));
   });
 
   test("using plain credentials", function(done) {

--- a/test/util.js
+++ b/test/util.js
@@ -107,6 +107,19 @@ function succeed(done) {
   return function() { done(); }
 }
 
+// Produce a callback that will complete the test successfully
+// only if the value is an object, it has the specified
+// attribute, and its value is equals to the expected value
+function succeedIfAttributeEquals(attribute, value, done) {
+  return function(object) {
+    if (object && !(object instanceof Error) && value === object[attribute]) {
+      return done();
+    }
+
+    done(new Error(attribute + " is not equal to " + value));
+  };
+}
+
 // Produce a callback that will fail the test, given either an error
 // (to be used as a failure continuation) or any other value (to be
 // used as a success continuation when failure is expected)
@@ -196,6 +209,7 @@ module.exports = {
   socketPair: socketPair,
   runServer: runServer,
   succeed: succeed,
+  succeedIfAttributeEquals: succeedIfAttributeEquals,
   fail: fail,
   latch: latch,
   completes: completes,


### PR DESCRIPTION
Provide extra settings inside the object configuration that were only available from url configs
like heartbeat interval.

Closes #229