### PR TITLE
add a consume example using a generator in a co routine

### DIFF
--- a/examples/receive_generator.js
+++ b/examples/receive_generator.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+'use strict';
+const co = require('co');
+const amqp = require('amqplib');
+const readline = require('readline');
+
+co(function* () {
+  const myConsumer = (msg) => {
+    if (msg !== null) {
+      console.log('consuming message %s in generator', JSON.stringify(msg.content.toString()));
+    }
+  };
+  const conn = yield amqp.connect('amqp://localhost');
+  try {
+    // create a message to consume
+    const q = 'hello';
+    const msg = 'Hello World!';
+    const channel = yield conn.createChannel();
+    yield channel.assertQueue(q);
+    channel.sendToQueue(q, new Buffer(msg));
+    console.log(" [x] Sent '%s'", msg);
+    // consume the message
+    yield channel.consume(q, myConsumer, { noAck: true });
+  }
+  catch (e) {
+    throw e;
+  }
+}).catch(err => {
+  console.warn('Error:', err);
+});
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout
+});
+
+// pend until message is consumed
+rl.question('newline to exit', () => process.exit());


### PR DESCRIPTION
I was looking for an example for a receive generator and saw an example for the a send generator. Here is a one for the reception of messages. It simply sends a message and consumes it within a generator using the 'co' library.