### PR TITLE
Split the username and password correctly

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -80,7 +80,7 @@ function openFrames(vhost, query, credentials, extraClientProperties) {
 function credentialsFromUrl(parts) {
   var user = 'guest', passwd = 'guest';
   if (parts.auth) {
-    var auth = parts.auth.split(':');
+    var auth = parts.auth.split(/:(.+)/);
     user = auth[0];
     passwd = auth[1];
   }


### PR DESCRIPTION
Split the username and password correctly so that the password can contain a ':' character.