### PR TITLE
Respect heartbeat=0 configuration - Fixes #344

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -225,7 +225,7 @@ C.open = function(allFields, openCallback0) {
       tunedOptions.channelMax =
         negotiate(fields.channelMax, allFields.channelMax);
       tunedOptions.heartbeat =
-        negotiate(fields.heartbeat, allFields.heartbeat);
+        (allFields.heartbeat === 0 ? 0 : negotiate(fields.heartbeat, allFields.heartbeat));
       send(defs.ConnectionTuneOk);
       send(defs.ConnectionOpen);
       expect(defs.ConnectionOpenOk, onOpenOk);


### PR DESCRIPTION
Keeping w/ the API docs:

> `heartbeat`: the period of the connection heartbeat, in seconds. Defaults to 0, meaning no heartbeat. OMG no heartbeat!

Allow `heartbeat=0` to be set. Fixes #344.