### PR TITLE
Adapt to new Buffer interface

### DIFF
--- a/bin/generate-defs.js
+++ b/bin/generate-defs.js
@@ -114,14 +114,15 @@ println(
 '*/');
 
 println("'use strict';"); nl();
-
+println('var Buffer = require("safe-buffer").Buffer;');
+nl()
 println('var codec = require("./codec");');
 println('var ints = require("buffer-more-ints");');
 println('var encodeTable = codec.encodeTable;');
 println('var decodeFields = codec.decodeFields;');
 nl();
 
-println('var SCRATCH = new Buffer(4096);');
+println('var SCRATCH = Buffer.alloc(4096);');
 println('var EMPTY_OBJECT = Object.freeze({});');
 
 println('module.exports.constants = %s',
@@ -238,7 +239,7 @@ function typeDesc(t) {
 function defaultValueRepr(arg) {
   switch (arg.type) {
   case 'longstr':
-    return format("new Buffer(%s)", JSON.stringify(arg.default));
+    return format("Buffer.from(%s)", JSON.stringify(arg.default));
   default:
     // assumes no tables as defaults
     return JSON.stringify(arg.default);
@@ -364,7 +365,7 @@ function encoderFn(method) {
     }
   }
 
-  println('var buffer = new Buffer(%d + varyingSize);', fixedSize);
+  println('var buffer = Buffer.alloc(%d + varyingSize);', fixedSize);
 
   println('buffer[0] = %d;', constants.FRAME_METHOD);
   println('buffer.writeUInt16BE(channel, 1);');
@@ -587,7 +588,7 @@ function encodePropsFn(props) {
     println('}');
   }
 
-  println('var buffer = new Buffer(%d + varyingSize);', fixedSize);
+  println('var buffer = Buffer.alloc(%d + varyingSize);', fixedSize);
 
   println('buffer[0] = %d', constants.FRAME_HEADER);
   println('buffer.writeUInt16BE(channel, 1);');

--- a/examples/headers.js
+++ b/examples/headers.js
@@ -37,6 +37,6 @@ function bindAndConsume(ch, ex, q) {
 
 function send(ch, ex) {
   // The headers for a message are given as an option to `publish`:
-  ch.publish(ex.exchange, '', new Buffer('hello'), {headers: {baz: 'boo'}});
-  ch.publish(ex.exchange, '', new Buffer('world'), {headers: {foo: 'bar'}});
+  ch.publish(ex.exchange, '', Buffer.from('hello'), {headers: {baz: 'boo'}});
+  ch.publish(ex.exchange, '', Buffer.from('world'), {headers: {foo: 'bar'}});
 }

--- a/examples/receive_generator.js
+++ b/examples/receive_generator.js
@@ -18,7 +18,7 @@ co(function* () {
     const msg = 'Hello World!';
     const channel = yield conn.createChannel();
     yield channel.assertQueue(q);
-    channel.sendToQueue(q, new Buffer(msg));
+    channel.sendToQueue(q, Buffer.from(msg));
     console.log(" [x] Sent '%s'", msg);
     // consume the message
     yield channel.consume(q, myConsumer, { noAck: true });

--- a/examples/send_generators.js
+++ b/examples/send_generators.js
@@ -21,7 +21,7 @@ co(function* () {
 
     yield channel.assertQueue(q);
 
-    channel.sendToQueue(q, new Buffer(msg));
+    channel.sendToQueue(q, Buffer.from(msg));
 
     // if message has been nacked, this will result in an error (rejected promise);
     yield channel.waitForConfirms();

--- a/examples/ssl.js
+++ b/examples/ssl.js
@@ -59,6 +59,6 @@ var open = amqp.connect('amqps://localhost', opts);
 open.then(function(conn) {
   process.on('SIGINT', conn.close.bind(conn));
   return conn.createChannel().then(function(ch) {
-    ch.sendToQueue('foo', new Buffer('Hello World!'));
+    ch.sendToQueue('foo', Buffer.from('Hello World!'));
   });
 }).then(null, console.warn);

--- a/examples/tutorials/callback_api/emit_log.js
+++ b/examples/tutorials/callback_api/emit_log.js
@@ -17,7 +17,7 @@ function on_connect(err, conn) {
     ch.assertExchange(ex, 'fanout', {durable: false});
     var msg = process.argv.slice(2).join(' ') ||
       'info: Hello World!';
-    ch.publish(ex, '', new Buffer(msg));
+    ch.publish(ex, '', Buffer.from(msg));
     console.log(" [x] Sent '%s'", msg);
     ch.close(function() { conn.close(); });
   }

--- a/examples/tutorials/callback_api/emit_log_direct.js
+++ b/examples/tutorials/callback_api/emit_log_direct.js
@@ -20,7 +20,7 @@ function on_connect(err, conn) {
   function on_channel_open(err, ch) {
     if (err !== null) return bail(err, conn);
     ch.assertExchange(ex, 'direct', exopts, function(err, ok) {
-      ch.publish(ex, severity, new Buffer(message));
+      ch.publish(ex, severity, Buffer.from(message));
       ch.close(function() { conn.close(); });
     });
   }

--- a/examples/tutorials/callback_api/emit_log_topic.js
+++ b/examples/tutorials/callback_api/emit_log_topic.js
@@ -17,7 +17,7 @@ function on_connect(err, conn) {
   conn.createChannel(function(err, ch) {
     ch.assertExchange(ex, 'topic', exopts, function(err, ok) {
       if (err !== null) return bail(err, conn);
-      ch.publish(ex, key, new Buffer(message));
+      ch.publish(ex, key, Buffer.from(message));
       console.log(" [x] Sent %s:'%s'", key, message);
       ch.close(function() { conn.close(); });
     });

--- a/examples/tutorials/callback_api/new_task.js
+++ b/examples/tutorials/callback_api/new_task.js
@@ -17,7 +17,7 @@ function on_connect(err, conn) {
     ch.assertQueue(q, {durable: true}, function(err, _ok) {
       if (err !== null) return bail(err, conn);
       var msg = process.argv.slice(2).join(' ') || "Hello World!";
-      ch.sendToQueue(q, new Buffer(msg), {persistent: true});
+      ch.sendToQueue(q, Buffer.from(msg), {persistent: true});
       console.log(" [x] Sent '%s'", msg);
       ch.close(function() { conn.close(); });
     });

--- a/examples/tutorials/callback_api/rpc_client.js
+++ b/examples/tutorials/callback_api/rpc_client.js
@@ -39,7 +39,7 @@ function on_connect(err, conn) {
       var queue = ok.queue;
       ch.consume(queue, maybeAnswer, {noAck:true});
       console.log(' [x] Requesting fib(%d)', n);
-      ch.sendToQueue('rpc_queue', new Buffer(n.toString()), {
+      ch.sendToQueue('rpc_queue', Buffer.from(n.toString()), {
         replyTo: queue, correlationId: correlationId
       });
     });

--- a/examples/tutorials/callback_api/rpc_server.js
+++ b/examples/tutorials/callback_api/rpc_server.js
@@ -35,7 +35,7 @@ function on_connect(err, conn) {
       var n = parseInt(msg.content.toString());
       console.log(' [.] fib(%d)', n);
       ch.sendToQueue(msg.properties.replyTo,
-                     new Buffer(fib(n).toString()),
+                     Buffer.from(fib(n).toString()),
                      {correlationId: msg.properties.correlationId});
       ch.ack(msg);
     }

--- a/examples/tutorials/callback_api/send.js
+++ b/examples/tutorials/callback_api/send.js
@@ -17,7 +17,7 @@ function on_connect(err, conn) {
     if (err !== null) return bail(err, conn);
     ch.assertQueue(q, {durable: false}, function(err, ok) {
       if (err !== null) return bail(err, conn);
-      ch.sendToQueue(q, new Buffer(msg));
+      ch.sendToQueue(q, Buffer.from(msg));
       console.log(" [x] Sent '%s'", msg);
       ch.close(function() { conn.close(); });
     });

--- a/examples/tutorials/emit_log.js
+++ b/examples/tutorials/emit_log.js
@@ -11,7 +11,7 @@ amqp.connect('amqp://localhost').then(function(conn) {
       'info: Hello World!';
 
     return ok.then(function() {
-      ch.publish(ex, '', new Buffer(message));
+      ch.publish(ex, '', Buffer.from(message));
       console.log(" [x] Sent '%s'", message);
       return ch.close();
     });

--- a/examples/tutorials/emit_log_direct.js
+++ b/examples/tutorials/emit_log_direct.js
@@ -12,7 +12,7 @@ amqp.connect('amqp://localhost').then(function(conn) {
     var ok = ch.assertExchange(ex, 'direct', {durable: false});
 
     return ok.then(function() {
-      ch.publish(ex, severity, new Buffer(message));
+      ch.publish(ex, severity, Buffer.from(message));
       console.log(" [x] Sent %s:'%s'", severity, message);
       return ch.close();
     });

--- a/examples/tutorials/emit_log_topic.js
+++ b/examples/tutorials/emit_log_topic.js
@@ -11,7 +11,7 @@ amqp.connect('amqp://localhost').then(function(conn) {
     var ex = 'topic_logs';
     var ok = ch.assertExchange(ex, 'topic', {durable: false});
     return ok.then(function() {
-      ch.publish(ex, key, new Buffer(message));
+      ch.publish(ex, key, Buffer.from(message));
       console.log(" [x] Sent %s:'%s'", key, message);
       return ch.close();
     });

--- a/examples/tutorials/new_task.js
+++ b/examples/tutorials/new_task.js
@@ -10,7 +10,7 @@ amqp.connect('amqp://localhost').then(function(conn) {
 
     return ok.then(function() {
       var msg = process.argv.slice(2).join(' ') || "Hello World!";
-      ch.sendToQueue(q, new Buffer(msg), {deliveryMode: true});
+      ch.sendToQueue(q, Buffer.from(msg), {deliveryMode: true});
       console.log(" [x] Sent '%s'", msg);
       return ch.close();
     });

--- a/examples/tutorials/rpc_client.js
+++ b/examples/tutorials/rpc_client.js
@@ -40,7 +40,7 @@ amqp.connect('amqp://localhost').then(function(conn) {
 
       ok = ok.then(function(queue) {
         console.log(' [x] Requesting fib(%d)', n);
-        ch.sendToQueue('rpc_queue', new Buffer(n.toString()), {
+        ch.sendToQueue('rpc_queue', Buffer.from(n.toString()), {
           correlationId: corrId, replyTo: queue
         });
       });

--- a/examples/tutorials/rpc_server.js
+++ b/examples/tutorials/rpc_server.js
@@ -31,7 +31,7 @@ amqp.connect('amqp://localhost').then(function(conn) {
       console.log(' [.] fib(%d)', n);
       var response = fib(n);
       ch.sendToQueue(msg.properties.replyTo,
-                     new Buffer(response.toString()),
+                     Buffer.from(response.toString()),
                      {correlationId: msg.properties.correlationId});
       ch.ack(msg);
     }

--- a/examples/tutorials/send.js
+++ b/examples/tutorials/send.js
@@ -15,7 +15,7 @@ amqp.connect('amqp://localhost').then(function(conn) {
       // (when `false`) that you should wait for the event `'drain'`
       // to fire before writing again. We're just doing the one write,
       // so we'll ignore it.
-      ch.sendToQueue(q, new Buffer(msg));
+      ch.sendToQueue(q, Buffer.from(msg));
       console.log(" [x] Sent '%s'", msg);
       return ch.close();
     });

--- a/examples/waitForConfirms.js
+++ b/examples/waitForConfirms.js
@@ -12,7 +12,7 @@ function mkCallback(i) {
 amqp.connect().then(function(c) {
   c.createConfirmChannel().then(function(ch) {
     for (var i=0; i < NUM_MSGS; i++) {
-      ch.publish('amq.topic', 'whatever', new Buffer('blah'), {}, mkCallback(i));
+      ch.publish('amq.topic', 'whatever', Buffer.from('blah'), {}, mkCallback(i));
     }
     ch.waitForConfirms().then(function() {
       console.log('All messages done');

--- a/lib/channel.js
+++ b/lib/channel.js
@@ -16,7 +16,7 @@ var EventEmitter = require('events').EventEmitter;
 var fmt = require('util').format;
 var IllegalOperationError = require('./error').IllegalOperationError;
 var stackCapture = require('./error').stackCapture;
-
+var Buffer = require('safe-buffer').Buffer
 function Channel(connection) {
   EventEmitter.call( this );
   this.connection = connection;
@@ -286,7 +286,7 @@ function acceptMessage(continuation) {
       
       // for zero-length messages, content frames aren't required.
       if (totalSize === 0) {
-        message.content = new Buffer(0);
+        message.content = Buffer.alloc(0);
         continuation(message);
         return acceptDeliveryOrReturn;
       }

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -9,6 +9,7 @@ var constants = defs.constants;
 var frame = require('./frame');
 var HEARTBEAT = frame.HEARTBEAT;
 var Mux = require('./mux').Mux;
+var Buffer = require('safe-buffer').Buffer
 
 var Duplex =
   require('stream').Duplex ||
@@ -43,7 +44,7 @@ function Connection(underlying) {
   this.muxer = new Mux(stream);
 
   // frames
-  this.rest = new Buffer(0);
+  this.rest = Buffer.alloc(0);
   this.frameMax = constants.FRAME_MIN_SIZE;
   this.sentSinceLastCheck = false;
   this.recvSinceLastCheck = false;
@@ -550,7 +551,7 @@ C.sendMessage = function(channel,
   var allLen = methodHeaderLen + bodyLen;
 
   if (allLen < SINGLE_CHUNK_THRESHOLD) {
-    var all = new Buffer(allLen);
+    var all = Buffer.alloc(allLen);
     var offset = mframe.copy(all, 0);
     offset += pframe.copy(all, offset);
 
@@ -560,7 +561,7 @@ C.sendMessage = function(channel,
   }
   else {
     if (methodHeaderLen < SINGLE_CHUNK_THRESHOLD) {
-      var both = new Buffer(methodHeaderLen);
+      var both = Buffer.alloc(methodHeaderLen);
       var offset = mframe.copy(both, 0);
       pframe.copy(both, offset);
       buffer.write(both);

--- a/lib/credentials.js
+++ b/lib/credentials.js
@@ -8,12 +8,13 @@
 //  * PLAIN (send username and password in the plain)
 //  * EXTERNAL (assume the server will figure out who you are from
 //    context, i.e., your SSL certificate)
+var Buffer = require('safe-buffer').Buffer
 
 module.exports.plain = function(user, passwd) {
   return {
     mechanism: 'PLAIN',
     response: function() {
-      return new Buffer(['', user, passwd].join(String.fromCharCode(0)))
+      return Buffer.from(['', user, passwd].join(String.fromCharCode(0)))
     },
     username: user,
     password: passwd
@@ -23,6 +24,6 @@ module.exports.plain = function(user, passwd) {
 module.exports.external = function() {
   return {
     mechanism: 'EXTERNAL',
-    response: function() { return new Buffer(''); }
+    response: function() { return Buffer.from(''); }
   }
 }

--- a/lib/frame.js
+++ b/lib/frame.js
@@ -7,6 +7,7 @@
 var defs = require('./defs');
 var constants = defs.constants;
 var decode = defs.decode;
+var Buffer = require('safe-buffer').Buffer
 
 var Bits = require('bitsyntax');
 
@@ -105,7 +106,7 @@ module.exports.decodeFrame = function(frame) {
 }
 
 // encoded heartbeat
-module.exports.HEARTBEAT_BUF = new Buffer([constants.FRAME_HEARTBEAT,
+module.exports.HEARTBEAT_BUF = Buffer.from([constants.FRAME_HEARTBEAT,
                                            0, 0, 0, 0, // size = 0
                                            0, 0, // channel = 0
                                            constants.FRAME_END]);

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/squaremo/amqp.node.git"
   },
   "engines": {
-    "node": ">=0.8 <6 || ^6"
+    "node": ">=0.8 <7.8"
   },
   "dependencies": {
     "bitsyntax": "~0.0.4",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
   },
   "dependencies": {
     "bitsyntax": "~0.0.4",
+    "bluebird": "^3.4.6",
     "buffer-more-ints": "0.0.2",
     "readable-stream": "1.x >=1.1.9",
-    "bluebird": "^3.4.6"
+    "safe-buffer": "^5.0.1"
   },
   "devDependencies": {
     "mocha": "~1",

--- a/test/callback_api.js
+++ b/test/callback_api.js
@@ -8,6 +8,7 @@ var schedule = util.schedule;
 var randomString = util.randomString;
 var kCallback = util.kCallback;
 var domain = require('domain');
+var Buffer = require('safe-buffer').Buffer;
 
 var URL = process.env.URL || 'amqp://localhost';
 
@@ -159,7 +160,7 @@ channel_test('send to queue and consume noAck', function(ch, done) {
       else done(new Error("message content doesn't match:" +
                           msg + " =/= " + m.content.toString()));
     }, {noAck: true, exclusive: true});
-    ch.sendToQueue(q.queue, new Buffer(msg));
+    ch.sendToQueue(q.queue, Buffer.from(msg));
   });
 });
 
@@ -175,7 +176,7 @@ channel_test('send to queue and consume ack', function(ch, done) {
       else done(new Error("message content doesn't match:" +
                           msg + " =/= " + m.content.toString()));
     }, {noAck: false, exclusive: true});
-    ch.sendToQueue(q.queue, new Buffer(msg));
+    ch.sendToQueue(q.queue, Buffer.from(msg));
   });
 });
 
@@ -183,7 +184,7 @@ channel_test('send to and get from queue', function(ch, done) {
   ch.assertQueue('', {exclusive: true}, function(e, q) {
     if (e != null) return done(e);
     var msg = randomString();
-    ch.sendToQueue(q.queue, new Buffer(msg));
+    ch.sendToQueue(q.queue, Buffer.from(msg));
     waitForMessages(ch, q.queue, function(e, _) {
       if (e != null) return done(e);
       ch.get(q.queue, {noAck: true}, function(e, m) {
@@ -210,12 +211,12 @@ confirm_channel_test('Receive confirmation', function(ch, done) {
   // An unroutable message, on the basis that you're not allowed a
   // queue with an empty name, and you can't make bindings to the
   // default exchange. Tricky eh?
-  ch.publish('', '', new Buffer('foo'), {}, done);
+  ch.publish('', '', Buffer.from('foo'), {}, done);
 });
 
 confirm_channel_test('Wait for confirms', function(ch, done) {
   for (var i=0; i < 1000; i++) {
-    ch.publish('', '', new Buffer('foo'), {});
+    ch.publish('', '', Buffer.from('foo'), {});
   }
   ch.waitForConfirms(done);
 });

--- a/test/channel.js
+++ b/test/channel.js
@@ -12,6 +12,7 @@ var completes = util.completes;
 var defs = require('../lib/defs');
 var conn_handshake = require('./connection').connection_handshake;
 var OPEN_OPTS = require('./connection').OPEN_OPTS;
+var Buffer = require('safe-buffer').Buffer;
 
 var LOG_ERRORS = process.env.LOG_ERRORS;
 
@@ -59,7 +60,7 @@ function channel_handshake(send, await) {
   return await(defs.ChannelOpen)()
     .then(function(open) {
       assert.notEqual(0, open.channel);
-      send(defs.ChannelOpenOk, {channelId: new Buffer('')}, open.channel);
+      send(defs.ChannelOpenOk, {channelId: Buffer.from('')}, open.channel);
       return open.channel;
     });
 }
@@ -304,7 +305,7 @@ test("publish all < single chunk threshold", channelTest(
         ch.sendMessage({
           exchange: 'foo', routingKey: 'bar',
           mandatory: false, immediate: false, ticket: 0
-        }, {}, new Buffer('foobar'));
+        }, {}, Buffer.from('foobar'));
       })
       .then(succeed(done), fail(done));
   },
@@ -324,7 +325,7 @@ test("publish content > single chunk threshold", channelTest(
       ch.sendMessage({
         exchange: 'foo', routingKey: 'bar',
         mandatory: false, immediate: false, ticket: 0
-      }, {}, new Buffer(3000));
+      }, {}, Buffer.alloc(3000));
     }, done);
   },
   function(send, await, done, ch) {
@@ -344,8 +345,8 @@ test("publish method & headers > threshold", channelTest(
         exchange: 'foo', routingKey: 'bar',
         mandatory: false, immediate: false, ticket: 0
       }, {
-        headers: {foo: new Buffer(3000)}
-      }, new Buffer('foobar'));
+        headers: {foo: Buffer.alloc(3000)}
+      }, Buffer.from('foobar'));
     }, done);
   },
   function(send, await, done, ch) {
@@ -364,11 +365,11 @@ test("publish zero-length message", channelTest(
       ch.sendMessage({
         exchange: 'foo', routingKey: 'bar',
         mandatory: false, immediate: false, ticket: 0
-      }, {}, new Buffer(0));
+      }, {}, Buffer.alloc(0));
       ch.sendMessage({
         exchange: 'foo', routingKey: 'bar',
         mandatory: false, immediate: false, ticket: 0
-      }, {}, new Buffer(0));
+      }, {}, Buffer.alloc(0));
     }, done);
   },
   function(send, await, done, ch) {
@@ -390,7 +391,7 @@ test("delivery", channelTest(
   },
   function(send, await, done, ch) {
     completes(function() {
-      send(defs.BasicDeliver, DELIVER_FIELDS, ch, new Buffer('barfoo'));
+      send(defs.BasicDeliver, DELIVER_FIELDS, ch, Buffer.from('barfoo'));
     }, done);
   }));
 
@@ -399,13 +400,13 @@ test("zero byte msg", channelTest(
     open(ch);
     ch.on('delivery', function(m) {
       completes(function() {
-        assert.deepEqual(new Buffer(0), m.content);
+        assert.deepEqual(Buffer.alloc(0), m.content);
       }, done);
     });
   },
   function(send, await, done, ch) {
     completes(function() {
-      send(defs.BasicDeliver, DELIVER_FIELDS, ch, new Buffer(''));
+      send(defs.BasicDeliver, DELIVER_FIELDS, ch, Buffer.from(''));
     }, done);
   }));
 
@@ -452,7 +453,7 @@ test("bad properties send", channelTest(
         ch.sendMessage({routingKey: 'foo',
                         exchange: 'amq.direct'},
                        {contentEncoding: 7},
-                       new Buffer('foobar'));
+                       Buffer.from('foobar'));
       });
     }, done);
   },
@@ -474,7 +475,7 @@ test("bad consumer", channelTest(
     open(ch);
   },
   function(send, await, done, ch) {
-    send(defs.BasicDeliver, DELIVER_FIELDS, ch, new Buffer('barfoo'));
+    send(defs.BasicDeliver, DELIVER_FIELDS, ch, Buffer.from('barfoo'));
     return await(defs.ChannelClose)()
       .then(function() {
         send(defs.ChannelCloseOk, {}, ch);
@@ -501,7 +502,7 @@ test("bad send in consumer", channelTest(
   function(send, await, done, ch) {
     completes(function() {
       send(defs.BasicDeliver, DELIVER_FIELDS, ch,
-           new Buffer('barfoo'));
+           Buffer.from('barfoo'));
     }, done);
     return await(defs.ChannelClose)()
       .then(function() {
@@ -520,7 +521,7 @@ test("return", channelTest(
   },
   function(send, await, done, ch) {
     completes(function() {
-      send(defs.BasicReturn, DELIVER_FIELDS, ch, new Buffer('barfoo'));
+      send(defs.BasicReturn, DELIVER_FIELDS, ch, Buffer.from('barfoo'));
     }, done);
   }));
 

--- a/test/codec.js
+++ b/test/codec.js
@@ -4,7 +4,7 @@ var codec = require('../lib/codec');
 var defs = require('../lib/defs');
 var assert = require('assert');
 var ints = require('buffer-more-ints');
-
+var Buffer = require('safe-buffer').Buffer
 var C = require('claire');
 var forAll = C.forAll;
 
@@ -36,7 +36,7 @@ var testCases = [
     ['string', {string: "boop"}, [6,115,116,114,105,110,103,83,0,0,0,4,98,111,111,112]],
 
     // buffer -> byte array
-    ['byte array from buffer', {bytes: new Buffer([1,2,3,4])},
+    ['byte array from buffer', {bytes: Buffer.from([1,2,3,4])},
      [5,98,121,116,101,115,120,0,0,0,4,1,2,3,4]],
 
     // boolean, void
@@ -69,7 +69,7 @@ suite("Explicit encodings", function() {
   testCases.forEach(function(tc) {
     var name = tc[0], val = tc[1], expect = tc[2];
     test(name, function() {
-      var buffer = new Buffer(1000);
+      var buffer = Buffer.alloc(1000);
       var size = codec.encodeTable(buffer, val, 0);
       var result = buffer.slice(4, size);
       assert.deepEqual(expect, bufferToArray(result));
@@ -82,7 +82,7 @@ suite("Explicit encodings", function() {
 var amqp = require('./data');
 
 function roundtrip_table(t) {
-  var buf = new Buffer(4096);
+  var buf = Buffer.alloc(4096);
   var size = codec.encodeTable(buf, t, 0);
   var decoded = codec.decodeFields(buf.slice(4, size)); // ignore the length-prefix
   try {
@@ -141,7 +141,7 @@ function assertEqualModuloDefaults(original, decodedFields) {
         // given as strings rather than buffers, but the decoded values
         // will be buffers.
         assert.deepEqual((arg.type === 'longstr') ?
-                         new Buffer(arg.default) : arg.default,
+                         Buffer.from(arg.default) : arg.default,
                          decodedValue);
       }
       else {

--- a/test/connect.js
+++ b/test/connect.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var connect = require('../lib/connect').connect;
+var Buffer = require('safe-buffer').Buffer
 var credentialsFromUrl = require('../lib/connect').credentialsFromUrl;
 var assert = require('assert');
 var util = require('./util');
@@ -107,7 +108,7 @@ suite("Connect API", function() {
   test("using unsupported mechanism", function(done) {
     var creds = {
       mechanism: 'UNSUPPORTED',
-      response: function() { return new Buffer(''); }
+      response: function() { return Buffer.from(''); }
     };
     connect(URL, {credentials: creds},
             kCallback(fail(done), succeed(done)));

--- a/test/data.js
+++ b/test/data.js
@@ -3,7 +3,7 @@
 'use strict';
 
 var C = require('claire');
-
+var Buffer = require('safe-buffer').Buffer;
 var forAll = C.forAll;
 var arb = C.data;
 var transform = C.transform;
@@ -36,7 +36,7 @@ function rangeInt(name, a, b) {
 }
 
 function toFloat32(i) {
-  var b = new Buffer(4);
+  var b = Buffer.alloc(4);
   b.writeFloatBE(i, 0);
   return b.readFloatBE(0);
 }
@@ -63,7 +63,7 @@ var ShortStr = label('shortstr',
 
 var LongStr = label('longstr',
                     transform(
-                      function(bytes) { return new Buffer(bytes); },
+                      function(bytes) { return Buffer.from(bytes); },
                       repeat(Octet)));
 
 var UShort = rangeInt('short-uint', 0, 0xffff);

--- a/test/frame.js
+++ b/test/frame.js
@@ -3,7 +3,7 @@
 var assert = require('assert');
 var succeed = require('./util').succeed;
 var fail = require('./util').fail;
-
+var Buffer = require('safe-buffer').Buffer;
 var connection = require('../lib/connection');
 var Frames = connection.Connection;
 var HEARTBEAT = require('../lib/frame').HEARTBEAT;
@@ -21,7 +21,7 @@ function inputs() {
   return new PassThrough({objectMode: true});
 }
 
-var HB = new Buffer([defs.constants.FRAME_HEARTBEAT,
+var HB = Buffer.from([defs.constants.FRAME_HEARTBEAT,
                      0, 0, // channel 0
                      0, 0, 0, 0, // zero size
                      defs.constants.FRAME_END]);
@@ -51,7 +51,7 @@ suite("Explicit parsing", function() {
       var input = inputs();
       var frames = new Frames(input);
       frames.frameMax = 5; //for the max frame test
-      input.write(new Buffer(bytes));
+      input.write(Buffer.from(bytes));
       frames.step(function(err, frame) {
         if (err != null) done();
         else done(new Error('Was a bogus frame!'));
@@ -166,7 +166,7 @@ var Content = transform(function(args) {
   return {
     method: args[0].fields,
     header: args[1].fields,
-    body: new Buffer(args[2])
+    body: Buffer.from(args[2])
   }
 }, sequence(amqp.methods['BasicDeliver'],
             amqp.properties['BasicProperties'], Body));


### PR DESCRIPTION
Old syntax for Buffer is being deprecated. I've added the dependency to safe buffer so that the new methods can be used. All tests run nicely in node 4 and node 7