### PR TITLE
Fix short integer encoding

### DIFF
--- a/lib/codec.js
+++ b/lib/codec.js
@@ -165,7 +165,7 @@ function encodeFieldValue(buffer, value, offset) {
                 buffer.writeInt8(val, offset); offset++;
             }
             else if (val >= -0x8000 && val < 0x8000) { //  short
-                tag('s');
+                tag('U');
                 buffer.writeInt16BE(val, offset); offset += 2;
             }
             else if (val >= -0x80000000 && val < 0x80000000) { // int
@@ -173,7 +173,7 @@ function encodeFieldValue(buffer, value, offset) {
                 buffer.writeInt32BE(val, offset); offset += 4;
             }
             else { // long
-                tag('l');
+                tag('L');
                 ints.writeInt64BE(buffer, val, offset); offset += 8;
             }
         }
@@ -215,6 +215,7 @@ function decodeFields(slice) {
         var tag = String.fromCharCode(slice[offset]); offset++;
         switch (tag) {
         case 'b':
+        case 'B':
             val = slice.readInt8(offset); offset++;
             break;
         case 'S':
@@ -222,6 +223,12 @@ function decodeFields(slice) {
             val = slice.toString('utf8', offset, offset + len);
             offset += len;
             break;
+        case 's':
+            len = slice.readUInt8(offset); offset++;
+            val = slice.toString('utf8', offset, offset + len);
+            offset += len;
+            break;
+        case 'i':
         case 'I':
             val = slice.readInt32BE(offset); offset += 4;
             break;
@@ -251,9 +258,11 @@ function decodeFields(slice) {
             val = slice.readFloatBE(offset); offset += 4;
             break;
         case 'l':
+        case 'L':
             val = ints.readInt64BE(slice, offset); offset += 8;
             break;
-        case 's':
+        case 'u':
+        case 'U':
             val = slice.readInt16BE(offset); offset += 2;
             break;
         case 't':


### PR DESCRIPTION
Messages encoded with this library are not conformant with AMQP specification - such an incorrect message might crash client (written in other language, in my case py-amqp-1.4.9) which is conformant with the AMQP 0-9-1 specification.

In short: `s` is for short string, not for short integer. For signed short integer is `U`.

Reference:
https://www.rabbitmq.com/resources/specs/amqp0-9-1.pdf (Technical Specifications, page 31)

PS.
This commit also changes signedness of the long integer. From now, every integer is encoded as a signed one.