### PR TITLE
Added flags closing and closed to connection and channel

### DIFF
--- a/lib/channel.js
+++ b/lib/channel.js
@@ -35,6 +35,8 @@ function Channel(connection) {
   }));
   // message frame state machine
   this.handleMessage = acceptDeliveryOrReturn;
+  this.closed = false;
+  this.closing = false;
 }
 inherits(Channel, EventEmitter);
 
@@ -157,6 +159,7 @@ function invalidateSend(ch, msg, stack) {
 
 // Move to entirely closed state.
 C.toClosed = function(capturedStack) {
+  this.closed = true;
   this._rejectPending();
   invalidateSend(this, 'Channel closed', capturedStack);
   this.accept = invalidOp('Channel closed', capturedStack);
@@ -169,6 +172,7 @@ C.toClosed = function(capturedStack) {
 // acknowledged the close, but before the channel is moved to the
 // closed state.
 C.toClosing = function(capturedStack, k) {
+  this.closing = true;
   var send = this.sendImmediately.bind(this);
   invalidateSend(this, 'Channel closing', capturedStack);
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -53,6 +53,8 @@ function Connection(underlying) {
   this.freeChannels = new BitSet();
   this.channels = [{channel: {accept: channel0(this)},
                     buffer: underlying}];
+  this.closed = false;
+  this.closing = false;
 }
 inherits(Connection, EventEmitter);
 
@@ -370,6 +372,7 @@ function invalidateSend(conn, msg, stack) {
 // This means we should not send more frames, anyway they will be
 // ignored. We also have to shut down all the channels.
 C.toClosing = function(capturedStack, k) {
+  this.closing = true;
   var send = this.sendMethod.bind(this);
 
   this.accept = function(f) {
@@ -397,6 +400,7 @@ C._closeChannels = function(capturedStack) {
 
 // A close has been confirmed. Cease all communication.
 C.toClosed = function(capturedStack, maybeErr) {
+  this.closed = true;
   this._closeChannels(capturedStack);
   var info = fmt('Connection closed (%s)',
                  (maybeErr) ? maybeErr.toString() : 'by client');


### PR DESCRIPTION
Since order of messages is not guaranteed when using multiple channels I have a use case where I want to keep a single channel open as long as possible and only create a new one when the old one is closed. I could use hack ways to detect that but I'd rather have explicit flags for that.