### PR TITLE
Error pending confirmation callbacks on channel close

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,6 +4,5 @@ scratch
 # node_modules is ignored anyway
 .travis.yml
 bin/amqp-rabbitmq-0.9.1.json
-bin/generate-defs.js
 etc/
 coverage/

--- a/lib/channel.js
+++ b/lib/channel.js
@@ -33,6 +33,12 @@ function Channel(connection) {
   this.on('nack', this.handleConfirm.bind(this, function(cb) {
     if (cb) cb(new Error('message nacked'));
   }));
+  this.on('close', function () {
+    var cb;
+    while (cb = this.unconfirmed.shift()) {
+      if (cb) cb(new Error('channel closed'));
+    }
+  })
   // message frame state machine
   this.handleMessage = acceptDeliveryOrReturn;
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "test": "make test",
-    "prepublish": "make"
+    "prepare": "make"
   },
   "keywords": [
     "AMQP",

--- a/test/channel_api.js
+++ b/test/channel_api.js
@@ -581,4 +581,17 @@ confirmtest('wait for confirms', function(ch) {
   return ch.waitForConfirms();
 })
 
+confirmtest('works when channel is closed', function(ch) {
+  for (var i=0; i < 1000; i++) {
+    ch.publish('', '', Buffer.from('foobar'), {});
+  }
+  return ch.close().then(function () {
+    return ch.waitForConfirms()
+  }).then(function () {
+    assert.strictEqual(true, false, 'Wait should have failed.')
+  }, function (e) {
+    assert.strictEqual(e.message, 'channel closed')
+  });
+});
+
 });


### PR DESCRIPTION
Otherwise waitForConfirms never terminates or terminates node

Additional this includes a commit https://github.com/squaremo/amqp.node/commit/099673edefdc3a7b570027c6f48793bbecf5789b, which makes it possible to install this module directly from git (instead of the published package), but I'm happy to drop this if preferred.