### PR TITLE
Fix stream becoming readable again

### DIFF
--- a/lib/mux.js
+++ b/lib/mux.js
@@ -55,26 +55,11 @@ Mux.prototype._readIncoming = function() {
   // are empty, or we exhaust our ability to accept chunks.
   function roundrobin(streams) {
     var s;
-    // if there's just one incoming stream we don't have to
-    // go through all the dequeue/enqueueing
-    if (streams.length === 1) {
-      s = streams.shift();
-      while (accepting) {
-        var chunk = s.read();
-        if (chunk !== null) {
-          accepting = out.write(chunk);
-        }
-        else break;
-      }
-      if (!accepting) streams.push(s);
-    }
-    else {
-      while (accepting && (s = streams.shift())) {
-        var chunk = s.read();
-        if (chunk !== null) {
-          accepting = out.write(chunk);
-          streams.push(s);
-        }
+    while (accepting && (s = streams.shift())) {
+      var chunk = s.read();
+      if (chunk !== null) {
+        accepting = out.write(chunk);
+        streams.push(s);
       }
     }
   }
@@ -105,7 +90,7 @@ Mux.prototype._readIncoming = function() {
 
 Mux.prototype._scheduleRead = function() {
   var self = this;
-  
+
   if (!self.scheduledRead) {
     schedule(function() {
       self.scheduledRead = false;


### PR DESCRIPTION
I'm not really sure how to test this for real, but under constant publishing I can trigger an occasional `Uncaught AssertionError [ERR_ASSERTION]: 0 == 1` https://github.com/squaremo/amqp.node/blob/c28c176dd74565c73957eebf00932a892d2aa840/lib/mux.js#L92

It seems that some kind of stream in this library is emitting `readable`, during read calls and causing this assertion to trip.