### PR TITLE
Close and destroy sockets on connection error.

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -151,7 +151,11 @@ function connect(url, socketOptions, openCallback) {
       if (err === null) {
         openCallback(null, c);
       }
-      else openCallback(err);
+      else {
+        sock.end();
+        sock.destroy();
+        openCallback(err);
+      }
     });
   }
 
@@ -174,7 +178,11 @@ function connect(url, socketOptions, openCallback) {
   }
 
   sock.once('error', function(err) {
-    if (!sockok) openCallback(err);
+    if (!sockok) {
+      sock.end();
+      sock.destroy();
+      openCallback(err);
+    }
   });
 
 }


### PR DESCRIPTION
Add `sock.end` and `sock.destroy` calls for `sock.once('error', ...)`
event handler and for `c.open(fields, ...)` callback - just like it was
done for connection timeout callback.

Resolves #513