### PR TITLE
Update package.json to reflect supported node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/squaremo/amqp.node.git"
   },
   "engines": {
-    "node": ">=0.8 <=9"
+    "node": ">=0.8 <=12"
   },
   "dependencies": {
     "bitsyntax": "~0.1.0",


### PR DESCRIPTION
Based on the current `.travis.yml`, node version 10, 11, 12 are supported. I have updated the package.json to reflect that. Otherwise amqplib fails to install when users have flag `engine-strict=true` in their .npmrc.