### PR TITLE
Install RabbitMQ as prereq of CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,10 @@ node_js:
    - "11.1"
    - "node"
 
-services:
-   - rabbitmq
+addons:
+  apt:
+    packages:
+      - rabbitmq-server
 
 before_install:
    - node --version | (grep  -v 'v5' && npm install -g npm@2) || true


### PR DESCRIPTION
RabbitMQ doesn't appear to be supported natively by TravisCI any
more. It disappeared in the upgrade from Trusty to Xenial.

To use it, yuo have to install it yourself, which I do here using an
addons.apt stanza.