### PR TITLE
Update the deprecated module with new module

### DIFF
--- a/examples/tutorials/package.json
+++ b/examples/tutorials/package.json
@@ -5,7 +5,7 @@
   "main": "send.js",
   "dependencies": {
     "amqplib": "../..",
-    "node-uuid": "*"
+    "uuid": "*"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
The node-uuid module is deprecated and should not be used any more. Change this dependency to uuid module is appropriate.