### PR TITLE
Introduce post-connection timeout setting

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -96,6 +96,7 @@ function connect(url, socketOptions, openCallback) {
 
   var noDelay = !!sockopts.noDelay;
   var timeout = sockopts.timeout;
+  var postConnectTimeout = sockopts.postConnectTimeout || 300000
   var keepAlive = !!sockopts.keepAlive;
   // 0 is default for node
   var keepAliveDelay = sockopts.keepAliveDelay || 0;
@@ -145,9 +146,8 @@ function connect(url, socketOptions, openCallback) {
 
     var c = new Connection(sock);
     c.open(fields, function(err, ok) {
-      // disable timeout once the connection is open, we don't want
-      // it fouling things
-      if (timeout) sock.setTimeout(0);
+      // revert to post-connection timeout (typically requires longer timeouts)
+      sock.setTimeout(postConnectTimeout);
       if (err === null) {
         openCallback(null, c);
       }


### PR DESCRIPTION
Currently, the timeout for the underlying socket is reset to `0` after a successful connection. This can lead to promises hanging indefinitely / callbacks not being invoked in case the server becomes unresponsive. On the other hand, just using the default socket timeout may be too short, and introduce runtime errors.

As a solution, this change introduces a second socket option `postConnectTimeout` which is being applied to the socket after a successful connection, rather than resetting the timeout to `0`. If the setting is not provided, a high default timeout of 300000 (5 minutes) is being set, which would still prevent indefinitely blocking clients.