### PR TITLE
fix: travis ci script to use xenial VM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: node_js
 node_js:
 - "0.8"


### PR DESCRIPTION
- use xenial VM image for travis CI.
- ~apt-get update before_install~
- ~npm run prepare to build before deploy~

since 0.5.5 is released, commit is updated