### PR TITLE
set SNI hostname for TLS connections

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -106,6 +106,7 @@ function connect(url, socketOptions, openCallback) {
   if (typeof url === 'object') {
     protocol = (url.protocol || 'amqp') + ':';
     sockopts.host = url.hostname;
+    sockopts.servername = url.hostname;
     sockopts.port = url.port || ((protocol === 'amqp:') ? 5672 : 5671);
 
     var user, pass;
@@ -130,6 +131,7 @@ function connect(url, socketOptions, openCallback) {
     var parts = URL(url, true); // yes, parse the query string
     protocol = parts.protocol;
     sockopts.host = parts.hostname;
+    sockopts.servername = parts.hostname;
     sockopts.port = parseInt(parts.port) || ((protocol === 'amqp:') ? 5672 : 5671);
     var vhost = parts.pathname ? parts.pathname.substr(1) : null;
     fields = openFrames(vhost, parts.query, sockopts.credentials || credentialsFromUrl(parts), extraClientProperties);


### PR DESCRIPTION
Is required if you have multiple AMQP servers behind a TLS load balancer. 