### PR TITLE
Allow newer node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,9 @@ node_js:
 - "9.11"
 - "10.10"
 - "11.1"
-- "node"
+- "12"
+- "13"
+- "node" # Latest stable Node version
 
 sudo: false
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/squaremo/amqp.node.git"
   },
   "engines": {
-    "node": ">=0.8 <=12"
+    "node": ">=0.8 <=14"
   },
   "dependencies": {
     "bitsyntax": "~0.1.0",


### PR DESCRIPTION
Fixes https://github.com/squaremo/amqp.node/issues/549.

# Context

We are using `amqp.node` with the latest NodeJS version (i.e. 13 and 14) but unfortunately,
`amqp.node` has its `package.json` fixed to an older version of NodeJS (12).

# Fix

This PR has two commits:

 - One for allowing newer engines of NodeJS
 - The other to support those new engines in travis
