### PR TITLE
Add option to set the passive flag for assertQueue & assertExchange

### DIFF
--- a/lib/api_args.js
+++ b/lib/api_args.js
@@ -67,7 +67,7 @@ Args.assertQueue = function(queue, options) {
     durable: (options.durable === undefined) ? true : options.durable,
     autoDelete: !!options.autoDelete,
     arguments: argt,
-    passive: false,
+    passive: !!options.passive,
     // deprecated but we have to include it
     ticket: 0,
     nowait: false
@@ -129,7 +129,7 @@ Args.assertExchange = function(exchange, type, options) {
     exchange: exchange,
     ticket: 0,
     type: type,
-    passive: false,
+    passive: !!options.passive,
     durable: (options.durable === undefined) ? true : options.durable,
     autoDelete: !!options.autoDelete,
     internal: !!options.internal,


### PR DESCRIPTION
This allows users to set the passive flag when using `assertQueue` and `assertExchange`, as certain rabbitmq servers require that and will refuse connections otherwise (e.g. rabbit.opensuse.org)