### PR TITLE
Drop support for node.js engines below v10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ JSON=amqp-rabbitmq-0.9.1.json
 RABBITMQ_CODEGEN=https://raw.githubusercontent.com/rabbitmq/rabbitmq-codegen
 AMQP_JSON=$(RABBITMQ_CODEGEN)/$(RABBITMQ_SRC_VERSION)/$(JSON)
 
-NODEJS_VERSIONS='0.8' '0.9' '0.10' '0.11' '0.12' '1.8.4' '2.5' '3.3' '4.9' '5.12' '6.17' '8.17' '9.11' '10.21' '11.15' '12.18' '13.14' '14.5' '15.8'
+NODEJS_VERSIONS='10.21' '11.15' '12.18' '13.14' '14.5' '15.8'
 
 MOCHA=./node_modules/.bin/mocha
 _MOCHA=./node_modules/.bin/_mocha

--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@
  * [API reference][gh-pages-apiref]
  * [Examples from RabbitMQ tutorials][tutes]
 
-A library for making AMQP 0-9-1 clients for Node.JS, and an AMQP 0-9-1
-client for Node.JS v0.8-0.12, v4-v15, and the intervening io.js
-releases.
+A library for making AMQP 0-9-1 clients for Node.JS, and an AMQP 0-9-1 client for Node.JS v10+.
 
 This library does not implement [AMQP
 1.0](https://github.com/squaremo/amqp.node/issues/63) or [AMQP

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/squaremo/amqp.node.git"
   },
   "engines": {
-    "node": ">=0.8 <=15"
+    "node": ">=10 <=15"
   },
   "dependencies": {
     "bitsyntax": "~0.1.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/squaremo/amqp.node.git"
   },
   "engines": {
-    "node": ">=10 <=15"
+    "node": ">=10"
   },
   "dependencies": {
     "bitsyntax": "~0.1.0",


### PR DESCRIPTION
It's a common practice to drop support for non-LTS Node versions, as it allows to reduce the maintenance burden. See more at:
https://nodejs.org/en/about/releases/

* [aws](https://aws.amazon.com/blogs/compute/node-js-14-x-runtime-now-available-in-aws-lambda/) supports nodejs v14, v12, v10 (will not be available soon)
* [gcd](https://cloud.google.com/appengine/docs/standard/nodejs/runtime#node.js-14) supports nodejs v14, v12, v10, v8 (deprecated)

Also, I see artifacts in the code
> something broken about domains in Node.JS v0.8 and mocha

or

```js
function isFloatingPoint(n) {
    return n >= 0x8000000000000000 ||
        (Math.abs(n) < 0x4000000000000
         && Math.floor(n) !== n);
```

instead of `Number.isSafeInteger(n)` (appeared in v0.12).

My future PRs will be based on this.
