### PR TITLE
Fix broken links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,10 +146,10 @@ really only useful for checking the kind and formatting of the errors.
     make coverage
     open file://`pwd`/coverage/lcov-report/index.html
 
-[gh-pages]: http://squaremo.github.com/amqp.node/
-[gh-pages-apiref]: http://squaremo.github.com/amqp.node/channel_api.html
+[gh-pages]: http://www.squaremobius.net/amqp.node/
+[gh-pages-apiref]: http://www.squaremobius.net/amqp.node/channel_api.html
 [nave]: https://github.com/isaacs/nave
-[tutes]: https://github.com/squaremo/amqp.node/tree/master/examples/tutorials
+[tutes]: https://github.com/squaremo/amqp.node/tree/main/examples/tutorials
 [rabbitmq-tutes]: http://www.rabbitmq.com/getstarted.html
-[changelog]: https://github.com/squaremo/amqp.node/blob/master/CHANGELOG.md
+[changelog]: https://github.com/squaremo/amqp.node/blob/main/CHANGELOG.md
 [docker]: https://www.docker.com/


### PR DESCRIPTION
The links to github pages were broken but I found I could get to working pages by changing github.com to github.io. It was then redirected to squaremobius.net.

The changelog and tutes link pointed to master that has been rename to main.