### PR TITLE
Remove old NodeJS versions from CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,12 @@
 language: node_js
 node_js:
-- "0.8"
-- "0.10"
-- "0.12"
-- "iojs-v1"
-- "iojs-v2"
-- "iojs-v3"
-- "4.2"
-- "5.5"
-- "6.12"
-- "8.9"
-- "9.11"
 - "10.10"
 - "11.1"
 - "12"
 - "13"
 - "14"
 - "15"
+- "16"
 - "node" # Latest stable Node version
 
 sudo: false


### PR DESCRIPTION
Support for Node prior to v10 has been removed. It would be nice to check against older NodeJS versions, but it can't be required by CI.
