### PR TITLE
Feature/modernize channel model

### DIFF
--- a/lib/channel_model.js
+++ b/lib/channel_model.js
@@ -10,6 +10,7 @@ const defs = require('./defs');
 const {BaseChannel} = require('./channel');
 const {acceptMessage} = require('./channel');
 const Args = require('./api_args');
+const {inspect} = require('./format');
 
 class ChannelModel extends EventEmitter {
   constructor(connection) {

--- a/lib/channel_model.js
+++ b/lib/channel_model.js
@@ -6,7 +6,7 @@
 
 const defs = require('./defs');
 const Promise = require('bluebird');
-const EventEmitter = require('events').EventEmitter;
+const EventEmitter = require('events');
 const BaseChannel = require('./channel').BaseChannel;
 const acceptMessage = require('./channel').acceptMessage;
 const Args = require('./api_args');

--- a/lib/channel_model.js
+++ b/lib/channel_model.js
@@ -26,19 +26,17 @@ class ChannelModel extends EventEmitter {
     return Promise.fromCallback(this.connection.close.bind(this.connection));
   }
 
-  createChannel() {
-    const c = new Channel(this.connection);
-    return c.open().then(openOk => { return c; });
+  async createChannel() {
+    const channel = new Channel(this.connection);
+    await channel.open();
+    return channel;
   }
 
-  createConfirmChannel() {
-    const c = new ConfirmChannel(this.connection);
-    return c.open()
-      .then(openOk => {
-        return c.rpc(defs.ConfirmSelect, {nowait: false},
-                     defs.ConfirmSelectOk)
-      })
-      .then(() => { return c; });
+  async createConfirmChannel() {
+    const channel = new ConfirmChannel(this.connection);
+    await channel.open();
+    await channel.rpc(defs.ConfirmSelect, {nowait: false}, defs.ConfirmSelectOk);
+    return channel;
   }
 }
 
@@ -54,13 +52,12 @@ class Channel extends BaseChannel {
   // An RPC that returns a 'proper' promise, which resolves to just the
   // response's fields; this is intended to be suitable for implementing
   // API procedures.
-  rpc(method, fields, expect) {
-    return Promise.fromCallback(cb => {
+  async rpc(method, fields, expect) {
+    const f = await Promise.fromCallback(cb => {
       return this._rpc(method, fields, expect, cb);
     })
-    .then(f => {
-      return f.fields;
-    });
+
+    return f.fields;
   }
 
   // Do the remarkably simple channel open handshake
@@ -161,53 +158,50 @@ class Channel extends BaseChannel {
     return this.publish('', queue, content, options);
   }
 
-  consume(queue, callback, options) {
+  async consume(queue, callback, options) {
     // NB we want the callback to be run synchronously, so that we've
     // registered the consumerTag before any messages can arrive.
     const fields = Args.consume(queue, options);
-    return Promise.fromCallback(cb => {
+    const ok = await Promise.fromCallback(cb => {
       this._rpc(defs.BasicConsume, fields, defs.BasicConsumeOk, cb);
     })
-    .then(ok => {
-      this.registerConsumer(ok.fields.consumerTag, callback);
-      return ok.fields;
-    });
+
+    this.registerConsumer(ok.fields.consumerTag, callback);
+    return ok.fields;
   }
 
-  cancel(consumerTag) {
-    return Promise.fromCallback(cb => {
+  async cancel(consumerTag) {
+    const ok = await Promise.fromCallback(cb => {
       this._rpc(defs.BasicCancel, Args.cancel(consumerTag),
             defs.BasicCancelOk,
             cb);
     })
-    .then(ok => {
-      this.unregisterConsumer(consumerTag);
-      return ok.fields;
-    });
+
+    this.unregisterConsumer(consumerTag);
+    return ok.fields;
   }
 
-  get(queue, options) {
+  async get(queue, options) {
     const fields = Args.get(queue, options);
-    return Promise.fromCallback(cb => {
-      return this.sendOrEnqueue(defs.BasicGet, fields, cb);
+    const f = await Promise.fromCallback(cb => {
+      this.sendOrEnqueue(defs.BasicGet, fields, cb);
     })
-    .then(f => {
-      if (f.id === defs.BasicGetEmpty) {
-        return false;
-      }
-      else if (f.id === defs.BasicGetOk) {
-        const fields = f.fields;
-        return new Promise(resolve => {
-          this.handleMessage = acceptMessage(m => {
-            m.fields = fields;
-            resolve(m);
-          });
+
+    if (f.id === defs.BasicGetEmpty) {
+      return false;
+    }
+    else if (f.id === defs.BasicGetOk) {
+      const fields = f.fields;
+      return new Promise(resolve => {
+        this.handleMessage = acceptMessage(m => {
+          m.fields = fields;
+          resolve(m);
         });
-      }
-      else {
-        throw new Error(`Unexpected response to BasicGet: ${inspect(f)}`);
-      }
-    });
+      });
+    }
+    else {
+      throw new Error(`Unexpected response to BasicGet: ${inspect(f)}`);
+    }
   }
 
   ack(message, allUpTo) {
@@ -246,6 +240,12 @@ class Channel extends BaseChannel {
                     Args.recover(),
                     defs.BasicRecoverOk);
   }
+
+  qos(count, global) {
+    return this.rpc(defs.BasicQos,
+                    Args.prefetch(count, global),
+                    defs.BasicQosOk);
+  }
 }
 
 // There are more options in AMQP than exposed here; RabbitMQ only
@@ -253,11 +253,7 @@ class Channel extends BaseChannel {
 // channels or consumers. RabbitMQ v3.3.0 and after treat prefetch
 // (without `global` set) as per-consumer (for consumers following),
 // and prefetch with `global` set as per-channel.
-Channel.prototype.prefetch = Channel.prototype.qos = function(count, global) {
-  return this.rpc(defs.BasicQos,
-                  Args.prefetch(count, global),
-                  defs.BasicQosOk);
-};
+Channel.prototype.prefetch = Channel.prototype.qos
 
 // Confirm channel. This is a channel with confirms 'switched on',
 // meaning sent messages will provoke a responding 'ack' or 'nack'
@@ -280,8 +276,7 @@ class ConfirmChannel extends Channel {
     const awaiting = [];
     const unconfirmed = this.unconfirmed;
     unconfirmed.forEach((val, index) => {
-      if (val === null); // already confirmed
-      else {
+      if (val !== null) {
         const confirmed = new Promise((resolve, reject) => {
           unconfirmed[index] = err => {
             if (val) val(err);

--- a/lib/channel_model.js
+++ b/lib/channel_model.js
@@ -7,8 +7,8 @@
 const defs = require('./defs');
 const Promise = require('bluebird');
 const EventEmitter = require('events');
-const BaseChannel = require('./channel').BaseChannel;
-const acceptMessage = require('./channel').acceptMessage;
+const {BaseChannel} = require('./channel');
+const {acceptMessage} = require('./channel');
 const Args = require('./api_args');
 
 class ChannelModel extends EventEmitter {

--- a/lib/channel_model.js
+++ b/lib/channel_model.js
@@ -270,10 +270,6 @@ Channel.prototype.prefetch = Channel.prototype.qos = function(count, global) {
 // its argument to signify 'nack'.
 
 class ConfirmChannel extends Channel {
-  constructor(connection) {
-    super(connection);
-  }
-
   publish(exchange, routingKey, content, options, cb) {
     this.pushConfirmCallback(cb);
     return Channel.prototype.publish.call(this, exchange, routingKey, content, options);

--- a/lib/channel_model.js
+++ b/lib/channel_model.js
@@ -6,7 +6,6 @@
 
 const defs = require('./defs');
 const Promise = require('bluebird');
-const inherits = require('util').inherits;
 const EventEmitter = require('events').EventEmitter;
 const BaseChannel = require('./channel').BaseChannel;
 const acceptMessage = require('./channel').acceptMessage;

--- a/lib/channel_model.js
+++ b/lib/channel_model.js
@@ -41,8 +41,6 @@ class ChannelModel extends EventEmitter {
   }
 }
 
-module.exports.ChannelModel = ChannelModel;
-
 // Channels
 
 class Channel extends BaseChannel {
@@ -249,8 +247,6 @@ class Channel extends BaseChannel {
   }
 }
 
-module.exports.Channel = Channel;
-
 // There are more options in AMQP than exposed here; RabbitMQ only
 // implements prefetch based on message count, and only for individual
 // channels or consumers. RabbitMQ v3.3.0 and after treat prefetch
@@ -300,3 +296,5 @@ class ConfirmChannel extends Channel {
 }
 
 module.exports.ConfirmChannel = ConfirmChannel;
+module.exports.Channel = Channel;
+module.exports.ChannelModel = ChannelModel;

--- a/lib/channel_model.js
+++ b/lib/channel_model.js
@@ -15,9 +15,9 @@ class ChannelModel extends EventEmitter {
   constructor(connection) {
     super();
     this.connection = connection;
-    const self = this;
+
     ['error', 'close', 'blocked', 'unblocked'].forEach(ev => {
-      connection.on(ev, self.emit.bind(self, ev));
+      connection.on(ev, this.emit.bind(this, ev));
     });
   }
 
@@ -56,9 +56,8 @@ class Channel extends BaseChannel {
   // response's fields; this is intended to be suitable for implementing
   // API procedures.
   rpc(method, fields, expect) {
-    const self = this;
     return Promise.fromCallback(cb => {
-      return self._rpc(method, fields, expect, cb);
+      return this._rpc(method, fields, expect, cb);
     })
     .then(f => {
       return f.fields;
@@ -75,9 +74,8 @@ class Channel extends BaseChannel {
   }
 
   close() {
-    const self = this;
     return Promise.fromCallback(cb => {
-      return self.closeBecause("Goodbye", defs.constants.REPLY_SUCCESS,
+      return this.closeBecause("Goodbye", defs.constants.REPLY_SUCCESS,
                       cb);
     });
   }
@@ -165,37 +163,34 @@ class Channel extends BaseChannel {
   }
 
   consume(queue, callback, options) {
-    const self = this;
     // NB we want the callback to be run synchronously, so that we've
     // registered the consumerTag before any messages can arrive.
     const fields = Args.consume(queue, options);
     return Promise.fromCallback(cb => {
-      self._rpc(defs.BasicConsume, fields, defs.BasicConsumeOk, cb);
+      this._rpc(defs.BasicConsume, fields, defs.BasicConsumeOk, cb);
     })
     .then(ok => {
-      self.registerConsumer(ok.fields.consumerTag, callback);
+      this.registerConsumer(ok.fields.consumerTag, callback);
       return ok.fields;
     });
   }
 
   cancel(consumerTag) {
-    const self = this;
     return Promise.fromCallback(cb => {
-      self._rpc(defs.BasicCancel, Args.cancel(consumerTag),
+      this._rpc(defs.BasicCancel, Args.cancel(consumerTag),
             defs.BasicCancelOk,
             cb);
     })
     .then(ok => {
-      self.unregisterConsumer(consumerTag);
+      this.unregisterConsumer(consumerTag);
       return ok.fields;
     });
   }
 
   get(queue, options) {
-    const self = this;
     const fields = Args.get(queue, options);
     return Promise.fromCallback(cb => {
-      return self.sendOrEnqueue(defs.BasicGet, fields, cb);
+      return this.sendOrEnqueue(defs.BasicGet, fields, cb);
     })
     .then(f => {
       if (f.id === defs.BasicGetEmpty) {
@@ -204,7 +199,7 @@ class Channel extends BaseChannel {
       else if (f.id === defs.BasicGetOk) {
         const fields = f.fields;
         return new Promise(resolve => {
-          self.handleMessage = acceptMessage(m => {
+          this.handleMessage = acceptMessage(m => {
             m.fields = fields;
             resolve(m);
           });

--- a/lib/channel_model.js
+++ b/lib/channel_model.js
@@ -4,263 +4,268 @@
 
 'use strict';
 
-var defs = require('./defs');
-var Promise = require('bluebird');
-var inherits = require('util').inherits;
-var EventEmitter = require('events').EventEmitter;
-var BaseChannel = require('./channel').BaseChannel;
-var acceptMessage = require('./channel').acceptMessage;
-var Args = require('./api_args');
+const defs = require('./defs');
+const Promise = require('bluebird');
+const inherits = require('util').inherits;
+const EventEmitter = require('events').EventEmitter;
+const BaseChannel = require('./channel').BaseChannel;
+const acceptMessage = require('./channel').acceptMessage;
+const Args = require('./api_args');
 
-function ChannelModel(connection) {
-  if (!(this instanceof ChannelModel))
-    return new ChannelModel(connection);
-  EventEmitter.call( this );
-  this.connection = connection;
-  var self = this;
-  ['error', 'close', 'blocked', 'unblocked'].forEach(function(ev) {
-    connection.on(ev, self.emit.bind(self, ev));
-  });
+class ChannelModel extends EventEmitter {
+  constructor(connection) {
+    super();
+    this.connection = connection;
+    const self = this;
+    ['error', 'close', 'blocked', 'unblocked'].forEach(ev => {
+      connection.on(ev, self.emit.bind(self, ev));
+    });
+  }
+
+  close() {
+    return Promise.fromCallback(this.connection.close.bind(this.connection));
+  }
+
+  createChannel() {
+    const c = new Channel(this.connection);
+    return c.open().then(openOk => { return c; });
+  }
+
+  createConfirmChannel() {
+    const c = new ConfirmChannel(this.connection);
+    return c.open()
+      .then(openOk => {
+        return c.rpc(defs.ConfirmSelect, {nowait: false},
+                     defs.ConfirmSelectOk)
+      })
+      .then(() => { return c; });
+  }
 }
-inherits(ChannelModel, EventEmitter);
 
 module.exports.ChannelModel = ChannelModel;
 
-var CM = ChannelModel.prototype;
-
-CM.close = function() {
-  return Promise.fromCallback(this.connection.close.bind(this.connection));
-};
-
 // Channels
 
-function Channel(connection) {
-  BaseChannel.call(this, connection);
-  this.on('delivery', this.handleDelivery.bind(this));
-  this.on('cancel', this.handleCancel.bind(this));
+class Channel extends BaseChannel {
+  constructor(connection) {
+    super(connection);
+    this.on('delivery', this.handleDelivery.bind(this));
+    this.on('cancel', this.handleCancel.bind(this));
+  }
+
+  // An RPC that returns a 'proper' promise, which resolves to just the
+  // response's fields; this is intended to be suitable for implementing
+  // API procedures.
+  rpc(method, fields, expect) {
+    const self = this;
+    return Promise.fromCallback(cb => {
+      return self._rpc(method, fields, expect, cb);
+    })
+    .then(f => {
+      return f.fields;
+    });
+  }
+
+  // Do the remarkably simple channel open handshake
+  open() {
+    return Promise.try(this.allocate.bind(this)).then(
+      ch => {
+        return ch.rpc(defs.ChannelOpen, {outOfBand: ""},
+                      defs.ChannelOpenOk);
+      });
+  }
+
+  close() {
+    const self = this;
+    return Promise.fromCallback(cb => {
+      return self.closeBecause("Goodbye", defs.constants.REPLY_SUCCESS,
+                      cb);
+    });
+  }
+
+  // === Public API, declaring queues and stuff ===
+
+  assertQueue(queue, options) {
+    return this.rpc(defs.QueueDeclare,
+                    Args.assertQueue(queue, options),
+                    defs.QueueDeclareOk);
+  }
+
+  checkQueue(queue) {
+    return this.rpc(defs.QueueDeclare,
+                    Args.checkQueue(queue),
+                    defs.QueueDeclareOk);
+  }
+
+  deleteQueue(queue, options) {
+    return this.rpc(defs.QueueDelete,
+                    Args.deleteQueue(queue, options),
+                    defs.QueueDeleteOk);
+  }
+
+  purgeQueue(queue) {
+    return this.rpc(defs.QueuePurge,
+                    Args.purgeQueue(queue),
+                    defs.QueuePurgeOk);
+  }
+
+  bindQueue(queue, source, pattern, argt) {
+    return this.rpc(defs.QueueBind,
+                    Args.bindQueue(queue, source, pattern, argt),
+                    defs.QueueBindOk);
+  }
+
+  unbindQueue(queue, source, pattern, argt) {
+    return this.rpc(defs.QueueUnbind,
+                    Args.unbindQueue(queue, source, pattern, argt),
+                    defs.QueueUnbindOk);
+  }
+
+  assertExchange(exchange, type, options) {
+    // The server reply is an empty set of fields, but it's convenient
+    // to have the exchange name handed to the continuation.
+    return this.rpc(defs.ExchangeDeclare,
+                    Args.assertExchange(exchange, type, options),
+                    defs.ExchangeDeclareOk)
+      .then(_ok => { return { exchange }; });
+  }
+
+  checkExchange(exchange) {
+    return this.rpc(defs.ExchangeDeclare,
+                    Args.checkExchange(exchange),
+                    defs.ExchangeDeclareOk);
+  }
+
+  deleteExchange(name, options) {
+    return this.rpc(defs.ExchangeDelete,
+                    Args.deleteExchange(name, options),
+                    defs.ExchangeDeleteOk);
+  }
+
+  bindExchange(dest, source, pattern, argt) {
+    return this.rpc(defs.ExchangeBind,
+                    Args.bindExchange(dest, source, pattern, argt),
+                    defs.ExchangeBindOk);
+  }
+
+  unbindExchange(dest, source, pattern, argt) {
+    return this.rpc(defs.ExchangeUnbind,
+                    Args.unbindExchange(dest, source, pattern, argt),
+                    defs.ExchangeUnbindOk);
+  }
+
+  // Working with messages
+
+  publish(exchange, routingKey, content, options) {
+    const fieldsAndProps = Args.publish(exchange, routingKey, options);
+    return this.sendMessage(fieldsAndProps, fieldsAndProps, content);
+  }
+
+  sendToQueue(queue, content, options) {
+    return this.publish('', queue, content, options);
+  }
+
+  consume(queue, callback, options) {
+    const self = this;
+    // NB we want the callback to be run synchronously, so that we've
+    // registered the consumerTag before any messages can arrive.
+    const fields = Args.consume(queue, options);
+    return Promise.fromCallback(cb => {
+      self._rpc(defs.BasicConsume, fields, defs.BasicConsumeOk, cb);
+    })
+    .then(ok => {
+      self.registerConsumer(ok.fields.consumerTag, callback);
+      return ok.fields;
+    });
+  }
+
+  cancel(consumerTag) {
+    const self = this;
+    return Promise.fromCallback(cb => {
+      self._rpc(defs.BasicCancel, Args.cancel(consumerTag),
+            defs.BasicCancelOk,
+            cb);
+    })
+    .then(ok => {
+      self.unregisterConsumer(consumerTag);
+      return ok.fields;
+    });
+  }
+
+  get(queue, options) {
+    const self = this;
+    const fields = Args.get(queue, options);
+    return Promise.fromCallback(cb => {
+      return self.sendOrEnqueue(defs.BasicGet, fields, cb);
+    })
+    .then(f => {
+      if (f.id === defs.BasicGetEmpty) {
+        return false;
+      }
+      else if (f.id === defs.BasicGetOk) {
+        const fields = f.fields;
+        return new Promise(resolve => {
+          self.handleMessage = acceptMessage(m => {
+            m.fields = fields;
+            resolve(m);
+          });
+        });
+      }
+      else {
+        throw new Error(`Unexpected response to BasicGet: ${inspect(f)}`);
+      }
+    });
+  }
+
+  ack(message, allUpTo) {
+    this.sendImmediately(
+      defs.BasicAck,
+      Args.ack(message.fields.deliveryTag, allUpTo));
+  }
+
+  ackAll() {
+    this.sendImmediately(defs.BasicAck, Args.ack(0, true));
+  }
+
+  nack(message, allUpTo, requeue) {
+    this.sendImmediately(
+      defs.BasicNack,
+      Args.nack(message.fields.deliveryTag, allUpTo, requeue));
+  }
+
+  nackAll(requeue) {
+    this.sendImmediately(defs.BasicNack,
+                         Args.nack(0, true, requeue));
+  }
+
+  // `Basic.Nack` is not available in older RabbitMQ versions (or in the
+  // AMQP specification), so you have to use the one-at-a-time
+  // `Basic.Reject`. This is otherwise synonymous with
+  // `#nack(message, false, requeue)`.
+  reject(message, requeue) {
+    this.sendImmediately(
+      defs.BasicReject,
+      Args.reject(message.fields.deliveryTag, requeue));
+  }
+
+  recover() {
+    return this.rpc(defs.BasicRecover,
+                    Args.recover(),
+                    defs.BasicRecoverOk);
+  }
 }
-inherits(Channel, BaseChannel);
 
 module.exports.Channel = Channel;
-
-CM.createChannel = function() {
-  var c = new Channel(this.connection);
-  return c.open().then(function(openOk) { return c; });
-};
-
-var C = Channel.prototype;
-
-// An RPC that returns a 'proper' promise, which resolves to just the
-// response's fields; this is intended to be suitable for implementing
-// API procedures.
-C.rpc = function(method, fields, expect) {
-  var self = this;
-  return Promise.fromCallback(function(cb) {
-    return self._rpc(method, fields, expect, cb);
-  })
-  .then(function(f) {
-    return f.fields;
-  });
-};
-
-// Do the remarkably simple channel open handshake
-C.open = function() {
-  return Promise.try(this.allocate.bind(this)).then(
-    function(ch) {
-      return ch.rpc(defs.ChannelOpen, {outOfBand: ""},
-                    defs.ChannelOpenOk);
-    });
-};
-
-C.close = function() {
-  var self = this;
-  return Promise.fromCallback(function(cb) {
-    return self.closeBecause("Goodbye", defs.constants.REPLY_SUCCESS,
-                    cb);
-  });
-};
-
-// === Public API, declaring queues and stuff ===
-
-C.assertQueue = function(queue, options) {
-  return this.rpc(defs.QueueDeclare,
-                  Args.assertQueue(queue, options),
-                  defs.QueueDeclareOk);
-};
-
-C.checkQueue = function(queue) {
-  return this.rpc(defs.QueueDeclare,
-                  Args.checkQueue(queue),
-                  defs.QueueDeclareOk);
-};
-
-C.deleteQueue = function(queue, options) {
-  return this.rpc(defs.QueueDelete,
-                  Args.deleteQueue(queue, options),
-                  defs.QueueDeleteOk);
-};
-
-C.purgeQueue = function(queue) {
-  return this.rpc(defs.QueuePurge,
-                  Args.purgeQueue(queue),
-                  defs.QueuePurgeOk);
-};
-
-C.bindQueue = function(queue, source, pattern, argt) {
-  return this.rpc(defs.QueueBind,
-                  Args.bindQueue(queue, source, pattern, argt),
-                  defs.QueueBindOk);
-};
-
-C.unbindQueue = function(queue, source, pattern, argt) {
-  return this.rpc(defs.QueueUnbind,
-                  Args.unbindQueue(queue, source, pattern, argt),
-                  defs.QueueUnbindOk);
-};
-
-C.assertExchange = function(exchange, type, options) {
-  // The server reply is an empty set of fields, but it's convenient
-  // to have the exchange name handed to the continuation.
-  return this.rpc(defs.ExchangeDeclare,
-                  Args.assertExchange(exchange, type, options),
-                  defs.ExchangeDeclareOk)
-    .then(function(_ok) { return { exchange: exchange }; });
-};
-
-C.checkExchange = function(exchange) {
-  return this.rpc(defs.ExchangeDeclare,
-                  Args.checkExchange(exchange),
-                  defs.ExchangeDeclareOk);
-};
-
-C.deleteExchange = function(name, options) {
-  return this.rpc(defs.ExchangeDelete,
-                  Args.deleteExchange(name, options),
-                  defs.ExchangeDeleteOk);
-};
-
-C.bindExchange = function(dest, source, pattern, argt) {
-  return this.rpc(defs.ExchangeBind,
-                  Args.bindExchange(dest, source, pattern, argt),
-                  defs.ExchangeBindOk);
-};
-
-C.unbindExchange = function(dest, source, pattern, argt) {
-  return this.rpc(defs.ExchangeUnbind,
-                  Args.unbindExchange(dest, source, pattern, argt),
-                  defs.ExchangeUnbindOk);
-};
-
-// Working with messages
-
-C.publish = function(exchange, routingKey, content, options) {
-  var fieldsAndProps = Args.publish(exchange, routingKey, options);
-  return this.sendMessage(fieldsAndProps, fieldsAndProps, content);
-};
-
-C.sendToQueue = function(queue, content, options) {
-  return this.publish('', queue, content, options);
-};
-
-C.consume = function(queue, callback, options) {
-  var self = this;
-  // NB we want the callback to be run synchronously, so that we've
-  // registered the consumerTag before any messages can arrive.
-  var fields = Args.consume(queue, options);
-  return Promise.fromCallback(function(cb) {
-    self._rpc(defs.BasicConsume, fields, defs.BasicConsumeOk, cb);
-  })
-  .then(function(ok) {
-    self.registerConsumer(ok.fields.consumerTag, callback);
-    return ok.fields;
-  });
-};
-
-C.cancel = function(consumerTag) {
-  var self = this;
-  return Promise.fromCallback(function(cb) {
-    self._rpc(defs.BasicCancel, Args.cancel(consumerTag),
-          defs.BasicCancelOk,
-          cb);
-  })
-  .then(function(ok) {
-    self.unregisterConsumer(consumerTag);
-    return ok.fields;
-  });
-};
-
-C.get = function(queue, options) {
-  var self = this;
-  var fields = Args.get(queue, options);
-  return Promise.fromCallback(function(cb) {
-    return self.sendOrEnqueue(defs.BasicGet, fields, cb);
-  })
-  .then(function(f) {
-    if (f.id === defs.BasicGetEmpty) {
-      return false;
-    }
-    else if (f.id === defs.BasicGetOk) {
-      var fields = f.fields;
-      return new Promise(function(resolve) {
-        self.handleMessage = acceptMessage(function(m) {
-          m.fields = fields;
-          resolve(m);
-        });
-      });
-    }
-    else {
-      throw new Error("Unexpected response to BasicGet: " +
-                             inspect(f));
-    }
-  })
-};
-
-C.ack = function(message, allUpTo) {
-  this.sendImmediately(
-    defs.BasicAck,
-    Args.ack(message.fields.deliveryTag, allUpTo));
-};
-
-C.ackAll = function() {
-  this.sendImmediately(defs.BasicAck, Args.ack(0, true));
-};
-
-C.nack = function(message, allUpTo, requeue) {
-  this.sendImmediately(
-    defs.BasicNack,
-    Args.nack(message.fields.deliveryTag, allUpTo, requeue));
-};
-
-C.nackAll = function(requeue) {
-  this.sendImmediately(defs.BasicNack,
-                       Args.nack(0, true, requeue));
-};
-
-// `Basic.Nack` is not available in older RabbitMQ versions (or in the
-// AMQP specification), so you have to use the one-at-a-time
-// `Basic.Reject`. This is otherwise synonymous with
-// `#nack(message, false, requeue)`.
-C.reject = function(message, requeue) {
-  this.sendImmediately(
-    defs.BasicReject,
-    Args.reject(message.fields.deliveryTag, requeue));
-};
 
 // There are more options in AMQP than exposed here; RabbitMQ only
 // implements prefetch based on message count, and only for individual
 // channels or consumers. RabbitMQ v3.3.0 and after treat prefetch
 // (without `global` set) as per-consumer (for consumers following),
 // and prefetch with `global` set as per-channel.
-C.prefetch = C.qos = function(count, global) {
+Channel.prototype.prefetch = Channel.prototype.qos = function(count, global) {
   return this.rpc(defs.BasicQos,
                   Args.prefetch(count, global),
                   defs.BasicQosOk);
-};
-
-C.recover = function() {
-  return this.rpc(defs.BasicRecover,
-                  Args.recover(),
-                  defs.BasicRecoverOk);
 };
 
 // Confirm channel. This is a channel with confirms 'switched on',
@@ -270,49 +275,38 @@ C.recover = function() {
 // with `null` as its argument to signify 'ack', or an exception as
 // its argument to signify 'nack'.
 
-function ConfirmChannel(connection) {
-  Channel.call(this, connection);
+class ConfirmChannel extends Channel {
+  constructor(connection) {
+    super(connection);
+  }
+
+  publish(exchange, routingKey, content, options, cb) {
+    this.pushConfirmCallback(cb);
+    return Channel.prototype.publish.call(this, exchange, routingKey, content, options);
+  }
+
+  sendToQueue(queue, content, options, cb) {
+    return this.publish('', queue, content, options, cb);
+  }
+
+  waitForConfirms() {
+    const awaiting = [];
+    const unconfirmed = this.unconfirmed;
+    unconfirmed.forEach((val, index) => {
+      if (val === null); // already confirmed
+      else {
+        const confirmed = new Promise((resolve, reject) => {
+          unconfirmed[index] = err => {
+            if (val) val(err);
+            if (err === null) resolve();
+            else reject(err);
+          };
+        });
+        awaiting.push(confirmed);
+      }
+    });
+    return Promise.all(awaiting);
+  }
 }
-inherits(ConfirmChannel, Channel);
 
 module.exports.ConfirmChannel = ConfirmChannel;
-
-CM.createConfirmChannel = function() {
-  var c = new ConfirmChannel(this.connection);
-  return c.open()
-    .then(function(openOk) {
-      return c.rpc(defs.ConfirmSelect, {nowait: false},
-                   defs.ConfirmSelectOk)
-    })
-    .then(function() { return c; });
-};
-
-var CC = ConfirmChannel.prototype;
-
-CC.publish = function(exchange, routingKey, content, options, cb) {
-  this.pushConfirmCallback(cb);
-  return C.publish.call(this, exchange, routingKey, content, options);
-};
-
-CC.sendToQueue = function(queue, content, options, cb) {
-  return this.publish('', queue, content, options, cb);
-};
-
-CC.waitForConfirms = function() {
-  var awaiting = [];
-  var unconfirmed = this.unconfirmed;
-  unconfirmed.forEach(function(val, index) {
-    if (val === null); // already confirmed
-    else {
-      var confirmed = new Promise(function(resolve, reject) {
-        unconfirmed[index] = function(err) {
-          if (val) val(err);
-          if (err === null) resolve();
-          else reject(err);
-        };
-      });
-      awaiting.push(confirmed);
-    }
-  });
-  return Promise.all(awaiting);
-};

--- a/lib/channel_model.js
+++ b/lib/channel_model.js
@@ -158,16 +158,17 @@ class Channel extends BaseChannel {
     return this.publish('', queue, content, options);
   }
 
-  async consume(queue, callback, options) {
+  consume(queue, callback, options) {
     // NB we want the callback to be run synchronously, so that we've
     // registered the consumerTag before any messages can arrive.
     const fields = Args.consume(queue, options);
-    const ok = await Promise.fromCallback(cb => {
+    return Promise.fromCallback(cb => {
       this._rpc(defs.BasicConsume, fields, defs.BasicConsumeOk, cb);
     })
-
-    this.registerConsumer(ok.fields.consumerTag, callback);
-    return ok.fields;
+    .then(ok => {
+      this.registerConsumer(ok.fields.consumerTag, callback);
+      return ok.fields;
+    });
   }
 
   async cancel(consumerTag) {
@@ -176,32 +177,34 @@ class Channel extends BaseChannel {
             defs.BasicCancelOk,
             cb);
     })
-
-    this.unregisterConsumer(consumerTag);
-    return ok.fields;
+    .then(ok => {
+      this.unregisterConsumer(consumerTag);
+      return ok.fields;
+    });
   }
 
-  async get(queue, options) {
+  get(queue, options) {
     const fields = Args.get(queue, options);
-    const f = await Promise.fromCallback(cb => {
-      this.sendOrEnqueue(defs.BasicGet, fields, cb);
+    return Promise.fromCallback(cb => {
+      return this.sendOrEnqueue(defs.BasicGet, fields, cb);
     })
-
-    if (f.id === defs.BasicGetEmpty) {
-      return false;
-    }
-    else if (f.id === defs.BasicGetOk) {
-      const fields = f.fields;
-      return new Promise(resolve => {
-        this.handleMessage = acceptMessage(m => {
-          m.fields = fields;
-          resolve(m);
+    .then(f => {
+      if (f.id === defs.BasicGetEmpty) {
+        return false;
+      }
+      else if (f.id === defs.BasicGetOk) {
+        const fields = f.fields;
+        return new Promise(resolve => {
+          this.handleMessage = acceptMessage(m => {
+            m.fields = fields;
+            resolve(m);
+          });
         });
-      });
-    }
-    else {
-      throw new Error(`Unexpected response to BasicGet: ${inspect(f)}`);
-    }
+      }
+      else {
+        throw new Error(`Unexpected response to BasicGet: ${inspect(f)}`);
+      }
+    });
   }
 
   ack(message, allUpTo) {

--- a/lib/channel_model.js
+++ b/lib/channel_model.js
@@ -4,9 +4,9 @@
 
 'use strict';
 
-const defs = require('./defs');
-const Promise = require('bluebird');
 const EventEmitter = require('events');
+const Promise = require('bluebird');
+const defs = require('./defs');
 const {BaseChannel} = require('./channel');
 const {acceptMessage} = require('./channel');
 const Args = require('./api_args');


### PR DESCRIPTION
Time for channel_model.js to be modernized

bf2a8d0 was not done manually... was executed using:
```
lebab --replace lib/channel_model.js  --transform arrow,let,includes,template,default-param,obj-shorthand,obj-method,arg-spread,arg-rest,for-each,class
```


<details>
<summary>Would be grate to get GitHub Actions for proper CI, in the meanwhile here is a log from node v16</summary>

```
npm run test

> amqplib@0.8.0 test
> make test

./node_modules/.bin/mocha --check-leaks -u tdd test/


  ✓ single input
  ✓ single input, resuming stream
  ✓ two sequential inputs
  ✓ two interleaved inputs
  ✓ unpipe
  ✓ roundrobin
  BitSet
    ✓ get bit
    ✓ clear bit
    ✓ next set of empty
    ✓ next set of one bit
    ✓ next set same bit
    ✓ next set following bit
    ✓ next clear of empty
    ✓ next clear of one set

  versionGreaterThan
    ✓ full spec
    ✓ partial spec
    ✓ not greater

  connect
    ✓ at all

  channel open
    ✓ at all
    ✓ open and close

  assert, check, delete
    ✓ assert, check, delete queue (53ms)
    ✓ assert, check, delete exchange (101ms)
    ✓ fail on check non-queue
    ✓ fail on check non-exchange

  bindings
    ✓ bind queue
    ✓ bind exchange

  sending messages
    ✓ send to queue and consume noAck
    ✓ send to queue and consume ack
    ✓ send to and get from queue

  ConfirmChannel
    ✓ Receive confirmation
    ✓ Wait for confirms (52ms)

  Error handling
    ✓ Throw error in connection open callback
    ✓ Channel open callback throws an error
    ✓ RPC callback throws error
    ✓ Get callback throws error
    ✓ Consume callback throws error
    ✓ Get from non-queue invokes error k
    ✓ Consume from non-queue invokes error k

  Connection errors
    ✓ socket close during open
    ✓ bad frame during open

  Connection open
    ✓ happy
    ✓ wrong first frame
    ✓ unexpected socket close

  Connection running
    ✓ wrong frame on channel 0
    ✓ unopened channel
    ✓ unexpected socket close
    ✓ connection.blocked
    ✓ connection.unblocked

  Connection close
    ✓ happy
    ✓ interleaved close frames
    ✓ server error close
    ✓ operator-intiated close
    ✓ double close

  heartbeats
    ✓ send heartbeat after open
    ✓ detect lack of heartbeats (63ms)

  channel open and close
    ✓ open
    ✓ bad server
    ✓ open, close
    ✓ server close
    ✓ overlapping channel/server close
    ✓ double close

  channel machinery
    ✓ RPC
    ✓ Bad RPC
    ✓ RPC on closed channel
    ✓ publish all < single chunk threshold
    ✓ publish content > single chunk threshold
    ✓ publish method & headers > threshold
    ✓ publish zero-length message
    ✓ delivery
    ✓ zero byte msg
    ✓ bad delivery
    ✓ bad content send
    ✓ bad properties send
    ✓ bad consumer
    ✓ bad send in consumer
    ✓ return
    ✓ cancel
    ✓ confirm ack
    ✓ confirm nack
    ✓ out-of-order acks
    ✓ not all out-of-order acks

  connect
    ✓ at all
    ✓ create channel

  assert, check, delete
    ✓ assert and check queue
    ✓ assert and check exchange
    ✓ fail on reasserting queue with different options
    ✓ fail on checking a queue that's not there
    ✓ fail on checking an exchange that's not there
    ✓ fail on reasserting exchange with different type
    ✓ channel break on publishing to non-exchange
    ✓ delete queue (71ms)
    ✓ delete exchange (225ms)

  sendMessage
    ✓ send to queue and get from queue
    ✓ send (and get) zero content to queue

  binding, consuming
    ✓ route message
    ✓ purge queue
    ✓ unbind queue
    ✓ consume via exchange-exchange binding
    ✓ unbind exchange
    ✓ cancel consumer
    ✓ cancelled consumer (52ms)
    ✓ ack
    ✓ nack
    ✓ reject
    ✓ prefetch
    ✓ close

  confirms
    ✓ message is confirmed
    ✓ multiple confirms
    ✓ wait for confirms (43ms)
    ✓ works when channel is closed (67ms)

  Implicit encodings
    ✓ byte
    ✓ byte max value
    ✓ byte min value
    ✓ < -128 promoted to signed short
    ✓ > 127 promoted to short
    ✓ < 2^15 still a short
    ✓ -2^15 still a short
    ✓ >= 2^15 promoted to int
    ✓ < -2^15 promoted to int
    ✓ < 2^31 still an int
    ✓ >= -2^31 still an int
    ✓ >= 2^31 promoted to long
    ✓ < -2^31 promoted to long
    ✓ float value
    ✓ negative float value
    ✓ string
    ✓ byte array from buffer
    ✓ true
    ✓ false
    ✓ null
    ✓ array
    ✓ object
    ✓ timestamp
    ✓ decimal
    ✓ float

  Domains
    ✓ <octet> domain
    ✓ <shortstr> domain
    ✓ <longstr> domain
    ✓ <short-uint> domain
    ✓ <long-uint> domain
    ✓ <longlong-uint> domain
    ✓ <short-int> domain
    ✓ <long-int> domain
    ✓ <longlong-int> domain
    ✓ <bit> domain
    ✓ <double> domain
    ✓ <float> domain
    ✓ <decimal> domain
    ✓ <timestamp> domain
    ✓ <table> domain
    ✓ <field-array> domain (93ms)

  Roundtrip values
    ✓ <octet> roundtrip
    ✓ <shortstr> roundtrip
    ✓ <longstr> roundtrip
    ✓ <short-uint> roundtrip
    ✓ <long-uint> roundtrip
    ✓ <longlong-uint> roundtrip
    ✓ <short-uint> roundtrip
    ✓ <short-int> roundtrip
    ✓ <long-int> roundtrip
    ✓ <bit> roundtrip
    ✓ <decimal> roundtrip
    ✓ <timestamp> roundtrip
    ✓ <double> roundtrip
    ✓ <float> roundtrip
    ✓ <field-array> roundtrip
    ✓ <table> roundtrip

  Roundtrip methods
    ✓ <ConnectionStart> roundtrip
    ✓ <ConnectionStartOk> roundtrip
    ✓ <ConnectionSecure> roundtrip
    ✓ <ConnectionSecureOk> roundtrip
    ✓ <ConnectionTune> roundtrip
    ✓ <ConnectionTuneOk> roundtrip
    ✓ <ConnectionOpen> roundtrip
    ✓ <ConnectionOpenOk> roundtrip
    ✓ <ConnectionClose> roundtrip
    ✓ <ConnectionCloseOk> roundtrip
    ✓ <ConnectionBlocked> roundtrip
    ✓ <ConnectionUnblocked> roundtrip
    ✓ <ChannelOpen> roundtrip
    ✓ <ChannelOpenOk> roundtrip
    ✓ <ChannelFlow> roundtrip
    ✓ <ChannelFlowOk> roundtrip
    ✓ <ChannelClose> roundtrip
    ✓ <ChannelCloseOk> roundtrip
    ✓ <AccessRequest> roundtrip
    ✓ <AccessRequestOk> roundtrip
    ✓ <ExchangeDeclare> roundtrip
    ✓ <ExchangeDeclareOk> roundtrip
    ✓ <ExchangeDelete> roundtrip
    ✓ <ExchangeDeleteOk> roundtrip
    ✓ <ExchangeBind> roundtrip
    ✓ <ExchangeBindOk> roundtrip
    ✓ <ExchangeUnbind> roundtrip
    ✓ <ExchangeUnbindOk> roundtrip
    ✓ <QueueDeclare> roundtrip
    ✓ <QueueDeclareOk> roundtrip
    ✓ <QueueBind> roundtrip
    ✓ <QueueBindOk> roundtrip
    ✓ <QueuePurge> roundtrip
    ✓ <QueuePurgeOk> roundtrip
    ✓ <QueueDelete> roundtrip
    ✓ <QueueDeleteOk> roundtrip
    ✓ <QueueUnbind> roundtrip
    ✓ <QueueUnbindOk> roundtrip
    ✓ <BasicQos> roundtrip
    ✓ <BasicQosOk> roundtrip
    ✓ <BasicConsume> roundtrip
    ✓ <BasicConsumeOk> roundtrip
    ✓ <BasicCancel> roundtrip
    ✓ <BasicCancelOk> roundtrip
    ✓ <BasicPublish> roundtrip
    ✓ <BasicReturn> roundtrip
    ✓ <BasicDeliver> roundtrip
    ✓ <BasicGet> roundtrip
    ✓ <BasicGetOk> roundtrip
    ✓ <BasicGetEmpty> roundtrip
    ✓ <BasicAck> roundtrip
    ✓ <BasicReject> roundtrip
    ✓ <BasicRecoverAsync> roundtrip
    ✓ <BasicRecover> roundtrip
    ✓ <BasicRecoverOk> roundtrip
    ✓ <BasicNack> roundtrip
    ✓ <TxSelect> roundtrip
    ✓ <TxSelectOk> roundtrip
    ✓ <TxCommit> roundtrip
    ✓ <TxCommitOk> roundtrip
    ✓ <TxRollback> roundtrip
    ✓ <TxRollbackOk> roundtrip
    ✓ <ConfirmSelect> roundtrip
    ✓ <ConfirmSelectOk> roundtrip

  Roundtrip properties
    ✓ <BasicProperties> roundtrip

  Credentials
    ✓ no creds
    ✓ usual user:pass
    ✓ missing user
    ✓ missing password
    ✓ escaped colons

  Connect API
    ✓ Connection refused
    ✓ bad URL
    ✓ wrongly typed open option
    ✓ serverProperties
    ✓ using custom heartbeat option
    ✓ wrongly typed heartbeat option
    ✓ using plain credentials
    ✓ using amqplain credentials
    ✓ using unsupported mechanism
    ✓ with a given connection timeout (53ms)

  Explicit parsing
    ✓ Parse heartbeat
    ✓ Parse partitioned
    ✓ Wrong sized frame
    ✓ Unknown method frame
    ✓ > max frame

  Parsing
    ✓ Parse trace of methods
    ✓ Parse concat'd methods (39ms)
    ✓ Parse partitioned methods

  Content framing
    ✓ Adhere to frame max (120ms)


  256 passing (2s)

```

<details>