### PR TITLE
Bring package-lock.json up to date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,14 +6,14 @@
   "packages": {
     "": {
       "name": "amqplib",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "bitsyntax": "~0.1.0",
         "bluebird": "^3.7.2",
         "buffer-more-ints": "~1.0.0",
         "readable-stream": "1.x >=1.1.9",
-        "url-parse": "~1.5.1"
+        "url-parse": "~1.5.3"
       },
       "devDependencies": {
         "claire": "0.4.1",
@@ -731,8 +731,9 @@
       "optional": true
     },
     "node_modules/url-parse": {
-      "version": "1.5.1",
-      "license": "MIT",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
+      "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -1279,7 +1280,9 @@
       "optional": true
     },
     "url-parse": {
-      "version": "1.5.1",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
+      "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"


### PR DESCRIPTION
The test workflow (rightfully) uses `npm ci`, which will balk if the
lockfile does not reflect version in package.json. This commit makes
sure they match, through

    npm install
