### PR TITLE
Modernisation 6 - Use parse int radix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Enable noUnusedFunctionParameters lint rule and fix all violations
 - Enable noUnusedVariables lint rule and remove all unused variables from codebase
 - Replace all var declarations with let/const for modern JavaScript standards
+- Ensure parseInt calls use explicit radix parameter for clarity and reliability
 
 ## v0.10.9
 - Add support for IPv6 urls

--- a/biome.json
+++ b/biome.json
@@ -23,7 +23,7 @@
         "noUnusedFunctionParameters": "error",
         "noUnusedVariables": "error",
         "noInnerDeclarations": "error",
-        "useParseIntRadix": "off",
+        "useParseIntRadix": "error",
         "noSwitchDeclarations": "off",
         "noInvalidUseBeforeDeclaration": "error",
         "noPrecisionLoss": "off"

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -50,7 +50,7 @@ function openFrames(vhost, query, credentials, extraClientProperties) {
   query = query || {};
 
   function intOrDefault(val, def) {
-    return val === undefined ? def : parseInt(val);
+    return val === undefined ? def : parseInt(val, 10);
   }
 
   const clientProperties = Object.create(CLIENT_PROPERTIES);
@@ -133,7 +133,7 @@ function connect(url, socketOptions, openCallback) {
     protocol = parts.protocol;
     sockopts.host = host;
     sockopts.servername = sockopts.servername || host;
-    sockopts.port = parseInt(parts.port) || (protocol === 'amqp:' ? 5672 : 5671);
+    sockopts.port = parseInt(parts.port, 10) || (protocol === 'amqp:' ? 5672 : 5671);
     const vhost = parts.pathname ? parts.pathname.substr(1) : null;
     fields = openFrames(vhost, parts.query, sockopts.credentials || credentialsFromUrl(parts), extraClientProperties);
   }

--- a/test/util.js
+++ b/test/util.js
@@ -163,7 +163,7 @@ function kCallback(k, ek) {
 // A noddy way to make tests depend on the node version.
 function versionGreaterThan(actual, spec) {
   function int(e) {
-    return parseInt(e);
+    return parseInt(e, 10);
   }
 
   const version = actual.split('.').map(int);


### PR DESCRIPTION
- Add explicit radix parameter (10) to all parseInt calls in lib/connect.js
- Add explicit radix parameter (10) to parseInt call in test/util.js
- Enable useParseIntRadix lint rule to prevent future violations
- Update changelog with parseInt radix requirement

🤖 Generated with [Claude Code](https://claude.ai/code)