### PR TITLE
Modernisation 7 - no precision loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Enable noUnusedVariables lint rule and remove all unused variables from codebase
 - Replace all var declarations with let/const for modern JavaScript standards
 - Ensure parseInt calls use explicit radix parameter for clarity and reliability
+- Fix precision loss in test data generators by using JavaScript safe integer limits
 
 ## v0.10.9
 - Add support for IPv6 urls

--- a/biome.json
+++ b/biome.json
@@ -26,7 +26,7 @@
         "useParseIntRadix": "error",
         "noSwitchDeclarations": "off",
         "noInvalidUseBeforeDeclaration": "error",
-        "noPrecisionLoss": "off"
+        "noPrecisionLoss": "error"
       },
       "style": {
         "useConst": "off",

--- a/test/data.js
+++ b/test/data.js
@@ -84,10 +84,10 @@ const LongStr = label(
 
 const UShort = rangeInt('short-uint', 0, 0xffff);
 const ULong = rangeInt('long-uint', 0, 0xffffffff);
-const ULongLong = rangeInt('longlong-uint', 0, 0xffffffffffffffff);
+const ULongLong = rangeInt('longlong-uint', 0, Number.MAX_SAFE_INTEGER);
 const Short = rangeInt('short-int', -0x8000, 0x7fff);
 const Long = rangeInt('long-int', -0x80000000, 0x7fffffff);
-const LongLong = rangeInt('longlong-int', -0x8000000000000000, 0x7fffffffffffffff);
+const LongLong = rangeInt('longlong-int', Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER);
 const Bit = label('bit', arb.Bool);
 const Double = label('double', asGenerator(floatChooser(308)));
 const Float = label('float', transform(toFloat32, floatChooser(38)));
@@ -260,7 +260,7 @@ const domainProps = [
   [
     LongLong,
     function (n) {
-      return n >= -0x8000000000000000 && n < 0x8000000000000000;
+      return n >= Number.MIN_SAFE_INTEGER && n <= Number.MAX_SAFE_INTEGER;
     },
   ],
   [


### PR DESCRIPTION
- Replace unsafe 64-bit integer limits with JavaScript safe integer constants
- Use Number.MAX_SAFE_INTEGER and Number.MIN_SAFE_INTEGER for LongLong ranges
- Update validation functions to match safe integer ranges
- Enable noPrecisionLoss lint rule to prevent future violations
- Ensures all generated test values maintain full precision in JavaScript

🤖 Generated with [Claude Code](https://claude.ai/code)