### PR TITLE
Modernisation 9 - Enable useConst rule by removing explicit configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Ensure parseInt calls use explicit radix parameter for clarity and reliability
 - Fix precision loss in test data generators by using JavaScript safe integer limits
 - Add block scoping to switch statement cases to prevent variable declaration issues
+- Enforce const usage for variables that are never reassigned
 
 ## v0.10.9
 - Add support for IPv6 urls

--- a/biome.json
+++ b/biome.json
@@ -20,7 +20,6 @@
         "useLiteralKeys": "off"
       },
       "style": {
-        "useConst": "off",
         "useNodejsImportProtocol": "off",
         "useTemplate": "off",
         "useExponentiationOperator": "off"

--- a/examples/tutorials/callback_api/rpc_server.js
+++ b/examples/tutorials/callback_api/rpc_server.js
@@ -45,7 +45,7 @@ function fib(n) {
   let a = 0,
     b = 1;
   for (let i = 0; i < n; i++) {
-    let c = a + b;
+    const c = a + b;
     a = b;
     b = c;
   }

--- a/examples/tutorials/rpc_server.js
+++ b/examples/tutorials/rpc_server.js
@@ -39,7 +39,7 @@ function fib(n) {
   let a = 0,
     b = 1;
   for (let i = 0; i < n; i++) {
-    let c = a + b;
+    const c = a + b;
     a = b;
     b = c;
   }


### PR DESCRIPTION
- Remove explicit useConst: "error" as it's enabled by default
- Simplify biome.json by relying on default recommended rules
- Update changelog with const enforcement entry

🤖 Generated with [Claude Code](https://claude.ai/code)