### PR TITLE
Modernisation 10 - Add node: protocol prefix to Node.js builtin module imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fix precision loss in test data generators by using JavaScript safe integer limits
 - Add block scoping to switch statement cases to prevent variable declaration issues
 - Enforce const usage for variables that are never reassigned
+- Add node: protocol prefix to Node.js builtin module imports for clarity
 
 ## v0.10.9
 - Add support for IPv6 urls

--- a/bin/generate-defs.js
+++ b/bin/generate-defs.js
@@ -1,4 +1,4 @@
-const format = require('util').format;
+const format = require('node:util').format;
 
 const defs = require('./amqp-rabbitmq-0.9.1.json');
 

--- a/biome.json
+++ b/biome.json
@@ -20,7 +20,6 @@
         "useLiteralKeys": "off"
       },
       "style": {
-        "useNodejsImportProtocol": "off",
         "useTemplate": "off",
         "useExponentiationOperator": "off"
       },

--- a/channel_api.js
+++ b/channel_api.js
@@ -1,6 +1,6 @@
 const raw_connect = require('./lib/connect').connect;
 const ChannelModel = require('./lib/channel_model').ChannelModel;
-const promisify = require('util').promisify;
+const promisify = require('node:util').promisify;
 
 function connect(url, connOptions) {
   return promisify(function (cb) {

--- a/examples/receive_generator.js
+++ b/examples/receive_generator.js
@@ -3,7 +3,7 @@
 'use strict';
 const co = require('co');
 const amqp = require('amqplib');
-const readline = require('readline');
+const readline = require('node:readline');
 
 co(function* () {
   const myConsumer = (msg) => {

--- a/examples/ssl.js
+++ b/examples/ssl.js
@@ -19,7 +19,7 @@
 //     openssl s_client -connect localhost:5671
 
 const amqp = require('../');
-const fs = require('fs');
+const fs = require('node:fs');
 
 // Assemble the SSL options; for verification we need at least
 // * a certificate to present to the server ('cert', in PEM format)

--- a/examples/tutorials/callback_api/receive_logs_direct.js
+++ b/examples/tutorials/callback_api/receive_logs_direct.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const amqp = require('amqplib/callback_api');
-const {basename} = require('path');
+const {basename} = require('node:path');
 
 const exchange = 'direct_logs';
 const severities = process.argv.slice(2);

--- a/examples/tutorials/callback_api/receive_logs_topic.js
+++ b/examples/tutorials/callback_api/receive_logs_topic.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const amqp = require('amqplib/callback_api');
-const {basename} = require('path');
+const {basename} = require('node:path');
 
 const exchange = 'topic_logs';
 const severities = process.argv.slice(2);

--- a/examples/tutorials/callback_api/rpc_client.js
+++ b/examples/tutorials/callback_api/rpc_client.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const amqp = require('amqplib/callback_api');
-const {basename} = require('path');
+const {basename} = require('node:path');
 const {v4: uuid} = require('uuid');
 
 const queue = 'rpc_queue';

--- a/examples/tutorials/receive_logs_direct.js
+++ b/examples/tutorials/receive_logs_direct.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const amqp = require('../..');
-const {basename} = require('path');
+const {basename} = require('node:path');
 
 const exchange = 'direct_logs';
 const bindingKeys = process.argv.slice(2);

--- a/examples/tutorials/receive_logs_topic.js
+++ b/examples/tutorials/receive_logs_topic.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const amqp = require('../..');
-const {basename} = require('path');
+const {basename} = require('node:path');
 
 const exchange = 'topic_logs';
 const bindingKeys = process.argv.slice(2);

--- a/examples/tutorials/rpc_client.js
+++ b/examples/tutorials/rpc_client.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const amqp = require('amqplib');
-const {basename} = require('path');
+const {basename} = require('node:path');
 const {v4: uuid} = require('uuid');
 
 const queue = 'rpc_queue';

--- a/lib/callback_model.js
+++ b/lib/callback_model.js
@@ -5,7 +5,7 @@
 'use strict';
 
 const defs = require('./defs');
-const EventEmitter = require('events');
+const EventEmitter = require('node:events');
 const BaseChannel = require('./channel').BaseChannel;
 const acceptMessage = require('./channel').acceptMessage;
 const Args = require('./api_args');

--- a/lib/channel.js
+++ b/lib/channel.js
@@ -10,9 +10,9 @@ const defs = require('./defs');
 const closeMsg = require('./format').closeMessage;
 const inspect = require('./format').inspect;
 const methodName = require('./format').methodName;
-const assert = require('assert');
-const EventEmitter = require('events');
-const fmt = require('util').format;
+const assert = require('node:assert');
+const EventEmitter = require('node:events');
+const fmt = require('node:util').format;
 const IllegalOperationError = require('./error').IllegalOperationError;
 const stackCapture = require('./error').stackCapture;
 

--- a/lib/channel_model.js
+++ b/lib/channel_model.js
@@ -4,8 +4,8 @@
 
 'use strict';
 
-const EventEmitter = require('events');
-const promisify = require('util').promisify;
+const EventEmitter = require('node:events');
+const promisify = require('node:util').promisify;
 const defs = require('./defs');
 const {BaseChannel} = require('./channel');
 const {acceptMessage} = require('./channel');

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -7,9 +7,9 @@
 'use strict';
 
 const URL = require('url-parse');
-const QS = require('querystring');
+const QS = require('node:querystring');
 const Connection = require('./connection').Connection;
-const fmt = require('util').format;
+const fmt = require('node:util').format;
 const credentials = require('./credentials');
 
 function copyInto(obj, target) {
@@ -163,9 +163,9 @@ function connect(url, socketOptions, openCallback) {
   }
 
   if (protocol === 'amqp:') {
-    sock = require('net').connect(sockopts, onConnect);
+    sock = require('node:net').connect(sockopts, onConnect);
   } else if (protocol === 'amqps:') {
-    sock = require('tls').connect(sockopts, onConnect);
+    sock = require('node:tls').connect(sockopts, onConnect);
   } else {
     throw new Error('Expected amqp: or amqps: as the protocol; got ' + protocol);
   }

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -10,8 +10,8 @@ const frame = require('./frame');
 const HEARTBEAT = frame.HEARTBEAT;
 const Mux = require('./mux').Mux;
 
-const Duplex = require('stream').Duplex;
-const EventEmitter = require('events');
+const Duplex = require('node:stream').Duplex;
+const EventEmitter = require('node:events');
 const Heart = require('./heartbeat').Heart;
 
 const methodName = require('./format').methodName;
@@ -19,8 +19,8 @@ const closeMsg = require('./format').closeMessage;
 const inspect = require('./format').inspect;
 
 const BitSet = require('./bitset').BitSet;
-const fmt = require('util').format;
-const PassThrough = require('stream').PassThrough;
+const fmt = require('node:util').format;
+const PassThrough = require('node:stream').PassThrough;
 const IllegalOperationError = require('./error').IllegalOperationError;
 const stackCapture = require('./error').stackCapture;
 

--- a/lib/error.js
+++ b/lib/error.js
@@ -1,4 +1,4 @@
-const inherits = require('util').inherits;
+const inherits = require('node:util').inherits;
 
 function trimStack(stack, num) {
   return stack && stack.split('\n').slice(num).join('\n');

--- a/lib/format.js
+++ b/lib/format.js
@@ -7,7 +7,7 @@
 'use strict';
 
 const defs = require('./defs');
-const format = require('util').format;
+const format = require('node:util').format;
 const HEARTBEAT = require('./frame').HEARTBEAT;
 
 module.exports.closeMessage = function (close) {

--- a/lib/heartbeat.js
+++ b/lib/heartbeat.js
@@ -47,7 +47,7 @@
 
 'use strict';
 
-const EventEmitter = require('events');
+const EventEmitter = require('node:events');
 
 // Exported so that we can mess with it in tests
 module.exports.UNITS_TO_MS = 1000;

--- a/lib/mux.js
+++ b/lib/mux.js
@@ -8,7 +8,7 @@
 // it then writes 'packets' from the upstreams to the given
 // downstream.
 
-const assert = require('assert');
+const assert = require('node:assert');
 
 const schedule = typeof setImmediate === 'function' ? setImmediate : process.nextTick;
 

--- a/test/callback_api.js
+++ b/test/callback_api.js
@@ -1,12 +1,12 @@
 'use strict';
 
-const assert = require('assert');
+const assert = require('node:assert');
 const api = require('../callback_api');
 const util = require('./util');
 const schedule = util.schedule;
 const randomString = util.randomString;
 const kCallback = util.kCallback;
-const domain = require('domain');
+const domain = require('node:domain');
 
 const URL = process.env.URL || 'amqp://localhost';
 

--- a/test/channel.js
+++ b/test/channel.js
@@ -2,8 +2,8 @@
 
 'use strict';
 
-const assert = require('assert');
-const promisify = require('util').promisify;
+const assert = require('node:assert');
+const promisify = require('node:util').promisify;
 const Channel = require('../lib/channel').Channel;
 const Connection = require('../lib/connection').Connection;
 const util = require('./util');

--- a/test/channel_api.js
+++ b/test/channel_api.js
@@ -1,13 +1,13 @@
 'use strict';
 
-const assert = require('assert');
+const assert = require('node:assert');
 const api = require('../channel_api');
 const util = require('./util');
 const succeed = util.succeed,
   fail = util.fail;
 const schedule = util.schedule;
 const randomString = util.randomString;
-const promisify = require('util').promisify;
+const promisify = require('node:util').promisify;
 
 const URL = process.env.URL || 'amqp://localhost';
 

--- a/test/codec.js
+++ b/test/codec.js
@@ -2,7 +2,7 @@
 
 const codec = require('../lib/codec');
 const defs = require('../lib/defs');
-const assert = require('assert');
+const assert = require('node:assert');
 const ints = require('buffer-more-ints');
 const C = require('claire');
 const forAll = C.forAll;

--- a/test/connect.js
+++ b/test/connect.js
@@ -3,15 +3,15 @@
 const connect = require('../lib/connect').connect;
 const credentialsFromUrl = require('../lib/connect').credentialsFromUrl;
 const defs = require('../lib/defs');
-const assert = require('assert');
+const assert = require('node:assert');
 const util = require('./util');
-const net = require('net');
+const net = require('node:net');
 const fail = util.fail,
   succeed = util.succeed,
   latch = util.latch,
   kCallback = util.kCallback,
   succeedIfAttributeEquals = util.succeedIfAttributeEquals;
-const format = require('util').format;
+const format = require('node:util').format;
 
 const URL = process.env.URL || 'amqp://localhost';
 
@@ -68,7 +68,7 @@ suite('Connect API', function () {
   });
 
   test('wrongly typed open option', function (done) {
-    const url = require('url');
+    const url = require('node:url');
     const parts = url.parse(URL, true);
     const q = parts.query || {};
     q.frameMax = 'NOT A NUMBER';
@@ -78,7 +78,7 @@ suite('Connect API', function () {
   });
 
   test('serverProperties', function (done) {
-    const url = require('url');
+    const url = require('node:url');
     const parts = url.parse(URL, true);
     const config = parts.query || {};
     connect(config, {}, function (err, connection) {
@@ -91,7 +91,7 @@ suite('Connect API', function () {
   });
 
   test('using custom heartbeat option', function (done) {
-    const url = require('url');
+    const url = require('node:url');
     const parts = url.parse(URL, true);
     const config = parts.query || {};
     config.heartbeat = 20;
@@ -99,7 +99,7 @@ suite('Connect API', function () {
   });
 
   test('wrongly typed heartbeat option', function (done) {
-    const url = require('url');
+    const url = require('node:url');
     const parts = url.parse(URL, true);
     const config = parts.query || {};
     config.heartbeat = 'NOT A NUMBER';
@@ -107,7 +107,7 @@ suite('Connect API', function () {
   });
 
   test('using plain credentials', function (done) {
-    const url = require('url');
+    const url = require('node:url');
     const parts = url.parse(URL, true);
     let u = 'guest',
       p = 'guest';
@@ -119,7 +119,7 @@ suite('Connect API', function () {
   });
 
   test('using amqplain credentials', function (done) {
-    const url = require('url');
+    const url = require('node:url');
     const parts = url.parse(URL, true);
     let u = 'guest',
       p = 'guest';

--- a/test/connection.js
+++ b/test/connection.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const assert = require('assert');
+const assert = require('node:assert');
 const defs = require('../lib/defs');
 const Connection = require('../lib/connection').Connection;
 const HEARTBEAT = require('../lib/frame').HEARTBEAT;

--- a/test/frame.js
+++ b/test/frame.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const assert = require('assert');
+const assert = require('node:assert');
 const connection = require('../lib/connection');
 const Frames = connection.Connection;
 const HEARTBEAT = require('../lib/frame').HEARTBEAT;
-const Stream = require('stream');
+const Stream = require('node:stream');
 const PassThrough = Stream.PassThrough;
 
 const defs = require('../lib/defs');

--- a/test/mux.js
+++ b/test/mux.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const assert = require('assert');
+const assert = require('node:assert');
 const Mux = require('../lib/mux').Mux;
-const PassThrough = require('stream').PassThrough;
+const PassThrough = require('node:stream').PassThrough;
 
 const latch = require('./util').latch;
 const schedule = require('./util').schedule;

--- a/test/util.js
+++ b/test/util.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const crypto = require('crypto');
+const crypto = require('node:crypto');
 const Connection = require('../lib/connection').Connection;
-const PassThrough = require('stream').PassThrough;
+const PassThrough = require('node:stream').PassThrough;
 const defs = require('../lib/defs');
-const assert = require('assert');
+const assert = require('node:assert');
 
 const schedule = typeof setImmediate === 'function' ? setImmediate : process.nextTick;
 


### PR DESCRIPTION
- Update all require() calls for Node.js builtins to use node: prefix
- Affects util, stream, events, crypto, net, tls, assert, path, fs, querystring, domain
- Improves clarity by distinguishing builtin modules from npm packages
- Remove explicit useNodejsImportProtocol config as it's enabled by default

🤖 Generated with [Claude Code](https://claude.ai/code)