### PR TITLE
Modernisation 16 - Replace global isNaN with Number.isNaN for safer type checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Remove redundant 'use strict' directives as modules are automatically in strict mode
 - Refactor assignment-in-expression patterns to improve code clarity and readability
 - Enforce strict equality checks (=== and !==) instead of loose equality (== and !=)
+- Replace global isNaN with Number.isNaN for safer type checking
 
 ## v0.10.9
 - Add support for IPv6 urls

--- a/biome.json
+++ b/biome.json
@@ -22,7 +22,7 @@
       "suspicious": {
         "noRedundantUseStrict": "error",
         "noAsyncPromiseExecutor": "off",
-        "noGlobalIsNan": "off",
+        "noGlobalIsNan": "error",
         "noRedeclare": "off",
         "noGlobalIsFinite": "off",
         "noPrototypeBuiltins": "off",

--- a/examples/tutorials/callback_api/rpc_client.js
+++ b/examples/tutorials/callback_api/rpc_client.js
@@ -7,7 +7,7 @@ const {v4: uuid} = require('uuid');
 const queue = 'rpc_queue';
 
 const n = parseInt(process.argv[2], 10);
-if (isNaN(n)) {
+if (Number.isNaN(n)) {
   console.warn('Usage: %s number', basename(process.argv[1]));
   process.exit(1);
 }

--- a/examples/tutorials/rpc_client.js
+++ b/examples/tutorials/rpc_client.js
@@ -7,7 +7,7 @@ const {v4: uuid} = require('uuid');
 const queue = 'rpc_queue';
 
 const n = parseInt(process.argv[2], 10);
-if (isNaN(n)) {
+if (Number.isNaN(n)) {
   console.warn('Usage: %s number', basename(process.argv[1]));
   process.exit(1);
 }

--- a/test/data.js
+++ b/test/data.js
@@ -43,7 +43,7 @@ function toFloat32(i) {
 function floatChooser(maxExp) {
   return function () {
     let n = Number.NaN;
-    while (isNaN(n)) {
+    while (Number.isNaN(n)) {
       const mantissa = Math.random() * 2 - 1;
       const exponent = chooseInt(0, maxExp);
       n = mantissa ** exponent;
@@ -268,13 +268,13 @@ const domainProps = [
   [
     Double,
     function (f) {
-      return !isNaN(f) && isFinite(f);
+      return !Number.isNaN(f) && isFinite(f);
     },
   ],
   [
     Float,
     function (f) {
-      return !isNaN(f) && isFinite(f) && Math.log(Math.abs(f)) * Math.LOG10E < 309;
+      return !Number.isNaN(f) && isFinite(f) && Math.log(Math.abs(f)) * Math.LOG10E < 309;
     },
   ],
   [


### PR DESCRIPTION
Replace all instances of the global isNaN function with Number.isNaN to avoid unsafe type coercion and improve numerical validation reliability.

🤖 Generated with [Claude Code](https://claude.ai/code)