### PR TITLE
Replace url-parse with WHATWG URL API

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -6,7 +6,7 @@
 
 'use strict';
 
-const URL = require('url-parse');
+const {URL} = require('url');
 const QS = require('querystring');
 const Connection = require('./connection').Connection;
 const fmt = require('util').format;
@@ -103,7 +103,11 @@ function connect(url, socketOptions, openCallback) {
 
   let protocol, fields;
   if (typeof url === 'object') {
-    protocol = (url.protocol || 'amqp') + ':';
+    if (typeof url.protocol === 'string' && url.protocol !== '') {
+      protocol = url.protocol.endsWith(':') ? url.protocol : url.protocol + ':';
+    } else {
+      protocol = 'amqp:';
+    }
     sockopts.host = url.hostname;
     sockopts.servername = sockopts.servername || url.hostname;
     sockopts.port = url.port || (protocol === 'amqp:' ? 5672 : 5671);
@@ -128,14 +132,22 @@ function connect(url, socketOptions, openCallback) {
 
     fields = openFrames(url.vhost, config, sockopts.credentials || credentials.plain(user, pass), extraClientProperties);
   } else {
-    const parts = URL(url, true); // yes, parse the query string
+    const parts = new URL(url);
     const host = parts.hostname.replace(/^\[|\]$/g, '');
     protocol = parts.protocol;
     sockopts.host = host;
     sockopts.servername = sockopts.servername || host;
     sockopts.port = parseInt(parts.port, 10) || (protocol === 'amqp:' ? 5672 : 5671);
     const vhost = parts.pathname ? parts.pathname.substr(1) : null;
-    fields = openFrames(vhost, parts.query, sockopts.credentials || credentialsFromUrl(parts), extraClientProperties);
+    const query = QS.parse(parts.search ? parts.search.slice(1) : '');
+    // QS.parse returns arrays for duplicate keys; match url-parse's first-value-wins behavior.
+    for (const key in query) {
+      const value = query[key];
+      if (Array.isArray(value)) {
+        query[key] = value[0];
+      }
+    }
+    fields = openFrames(vhost, query, sockopts.credentials || credentialsFromUrl(parts), extraClientProperties);
   }
 
   let sockok = false;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "0.10.9",
       "license": "MIT",
       "dependencies": {
-        "buffer-more-ints": "~1.0.0",
-        "url-parse": "~1.5.10"
+        "buffer-more-ints": "~1.0.0"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.2.2",
@@ -21,7 +20,7 @@
         "uglify-js": "2.8.x"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2498,11 +2497,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
-    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -2559,11 +2553,6 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
-    },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "node_modules/resolve-from": {
       "version": "5.0.0",
@@ -2909,15 +2898,6 @@
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "dev": true,
       "optional": true
-    },
-    "node_modules/url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
-      }
     },
     "node_modules/uuid": {
       "version": "3.4.0",
@@ -4882,11 +4862,6 @@
         "fromentries": "^1.2.0"
       }
     },
-    "querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
-    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -4931,11 +4906,6 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
-    },
-    "requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve-from": {
       "version": "5.0.0",
@@ -5197,15 +5167,6 @@
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "dev": true,
       "optional": true
-    },
-    "url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "requires": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
-      }
     },
     "uuid": {
       "version": "3.4.0",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "buffer-more-ints": "~1.0.0",
-    "url-parse": "~1.5.10"
+    "buffer-more-ints": "~1.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.2.2",

--- a/test/connect.js
+++ b/test/connect.js
@@ -13,9 +13,7 @@ const fail = util.fail,
   succeedIfAttributeEquals = util.succeedIfAttributeEquals;
 const format = require('util').format;
 
-const URL = process.env.URL || 'amqp://localhost';
-
-const urlparse = require('url-parse');
+const AMQP_URL = process.env.URL || 'amqp://localhost';
 
 suite('Credentials', function () {
   function checkCreds(creds, user, pass, done) {
@@ -29,27 +27,27 @@ suite('Credentials', function () {
   }
 
   test('no creds', function (done) {
-    const parts = urlparse('amqp://localhost');
+    const parts = new URL('amqp://localhost');
     const creds = credentialsFromUrl(parts);
     checkCreds(creds, 'guest', 'guest', done);
   });
   test('usual user:pass', function (done) {
-    const parts = urlparse('amqp://user:pass@localhost');
+    const parts = new URL('amqp://user:pass@localhost');
     const creds = credentialsFromUrl(parts);
     checkCreds(creds, 'user', 'pass', done);
   });
   test('missing user', function (done) {
-    const parts = urlparse('amqps://:password@localhost');
+    const parts = new URL('amqps://:password@localhost');
     const creds = credentialsFromUrl(parts);
     checkCreds(creds, '', 'password', done);
   });
   test('missing password', function (done) {
-    const parts = urlparse('amqps://username:@localhost');
+    const parts = new URL('amqps://username:@localhost');
     const creds = credentialsFromUrl(parts);
     checkCreds(creds, 'username', '', done);
   });
   test('escaped colons', function (done) {
-    const parts = urlparse('amqp://user%3Aname:pass%3Aword@localhost');
+    const parts = new URL('amqp://user%3Aname:pass%3Aword@localhost');
     const creds = credentialsFromUrl(parts);
     checkCreds(creds, 'user:name', 'pass:word', done);
   });
@@ -67,20 +65,22 @@ suite('Connect API', function () {
     });
   });
 
+  test('empty protocol on URL-like object defaults to amqp', function (done) {
+    assert.doesNotThrow(function () {
+      connect({protocol: '', hostname: 'localhost', port: 23450}, {}, kCallback(fail(done), succeed(done)));
+    });
+  });
+
   test('wrongly typed open option', function (done) {
-    const url = require('url');
-    const parts = url.parse(URL, true);
-    const q = parts.query || {};
-    q.frameMax = 'NOT A NUMBER';
-    parts.query = q;
-    const u = url.format(parts);
+    const parts = new URL(AMQP_URL);
+    parts.searchParams.set('frameMax', 'NOT A NUMBER');
+    const u = parts.toString();
     connect(u, {}, kCallback(fail(done), succeed(done)));
   });
 
   test('serverProperties', function (done) {
-    const url = require('url');
-    const parts = url.parse(URL, true);
-    const config = parts.query || {};
+    const parts = new URL(AMQP_URL);
+    const config = Object.fromEntries(parts.searchParams.entries());
     connect(config, {}, function (err, connection) {
       if (err) {
         return done(err);
@@ -91,43 +91,39 @@ suite('Connect API', function () {
   });
 
   test('using custom heartbeat option', function (done) {
-    const url = require('url');
-    const parts = url.parse(URL, true);
-    const config = parts.query || {};
+    const parts = new URL(AMQP_URL);
+    const config = Object.fromEntries(parts.searchParams.entries());
     config.heartbeat = 20;
     connect(config, {}, kCallback(succeedIfAttributeEquals('heartbeat', 20, done), fail(done)));
   });
 
   test('wrongly typed heartbeat option', function (done) {
-    const url = require('url');
-    const parts = url.parse(URL, true);
-    const config = parts.query || {};
+    const parts = new URL(AMQP_URL);
+    const config = Object.fromEntries(parts.searchParams.entries());
     config.heartbeat = 'NOT A NUMBER';
     connect(config, {}, kCallback(fail(done), succeed(done)));
   });
 
   test('using plain credentials', function (done) {
-    const url = require('url');
-    const parts = url.parse(URL, true);
+    const parts = new URL(AMQP_URL);
     let u = 'guest',
       p = 'guest';
-    if (parts.auth) {
-      const auth = parts.auth.split(':');
-      (u = auth[0]), (p = auth[1]);
+    if (parts.username !== '' || parts.password !== '') {
+      u = unescape(parts.username);
+      p = unescape(parts.password);
     }
-    connect(URL, {credentials: require('../lib/credentials').plain(u, p)}, kCallback(succeed(done), fail(done)));
+    connect(AMQP_URL, {credentials: require('../lib/credentials').plain(u, p)}, kCallback(succeed(done), fail(done)));
   });
 
   test('using amqplain credentials', function (done) {
-    const url = require('url');
-    const parts = url.parse(URL, true);
+    const parts = new URL(AMQP_URL);
     let u = 'guest',
       p = 'guest';
-    if (parts.auth) {
-      const auth = parts.auth.split(':');
-      (u = auth[0]), (p = auth[1]);
+    if (parts.username !== '' || parts.password !== '') {
+      u = unescape(parts.username);
+      p = unescape(parts.password);
     }
-    connect(URL, {credentials: require('../lib/credentials').amqplain(u, p)}, kCallback(succeed(done), fail(done)));
+    connect(AMQP_URL, {credentials: require('../lib/credentials').amqplain(u, p)}, kCallback(succeed(done), fail(done)));
   });
 
   test('ipv6', function (done) {
@@ -146,7 +142,7 @@ suite('Connect API', function () {
         return Buffer.from('');
       },
     };
-    connect(URL, {credentials: creds}, kCallback(fail(done), succeed(done)));
+    connect(AMQP_URL, {credentials: creds}, kCallback(fail(done), succeed(done)));
   });
 
   test('with a given connection timeout', function (done) {
@@ -202,6 +198,99 @@ suite('Errors on connect', function () {
 
     connect('amqp://localhost:' + server.address().port, {}, function (err) {
       if (!err) bothDone(new Error('Expected authentication error'));
+      bothDone();
+    });
+  });
+
+  test('uses vhost from URL pathname', function (done) {
+    const expectedVhost = 'my-vhost';
+    const bothDone = latch(2, done);
+
+    server = net
+      .createServer(function (socket) {
+        socket.once('data', function (protocolHeader) {
+          assert.deepStrictEqual(protocolHeader, Buffer.from('AMQP' + String.fromCharCode(0, 0, 9, 1)));
+          util.runServer(socket, function (send, wait) {
+            send(defs.ConnectionStart, {
+              versionMajor: 0,
+              versionMinor: 9,
+              serverProperties: {},
+              mechanisms: Buffer.from('PLAIN'),
+              locales: Buffer.from('en_US'),
+            });
+
+            wait(defs.ConnectionStartOk)()
+              .then(function () {
+                send(defs.ConnectionTune, {
+                  channelMax: 0,
+                  heartbeat: 0,
+                  frameMax: 0,
+                });
+              })
+              .then(wait(defs.ConnectionTuneOk))
+              .then(wait(defs.ConnectionOpen))
+              .then(function (frame) {
+                assert.strictEqual(frame.fields.virtualHost, expectedVhost);
+                send(defs.ConnectionOpenOk, {knownHosts: ''});
+                bothDone();
+              })
+              .catch(bothDone);
+          });
+        });
+      })
+      .listen(0);
+
+    connect('amqp://localhost:' + server.address().port + '/' + expectedVhost, {}, function (err, connection) {
+      if (err) {
+        return bothDone(err);
+      }
+      connection.close();
+      bothDone();
+    });
+  });
+
+  test('uses first locale when query contains duplicates', function (done) {
+    const bothDone = latch(2, done);
+
+    server = net
+      .createServer(function (socket) {
+        socket.once('data', function (protocolHeader) {
+          assert.deepStrictEqual(protocolHeader, Buffer.from('AMQP' + String.fromCharCode(0, 0, 9, 1)));
+          util.runServer(socket, function (send, wait) {
+            send(defs.ConnectionStart, {
+              versionMajor: 0,
+              versionMinor: 9,
+              serverProperties: {},
+              mechanisms: Buffer.from('PLAIN'),
+              locales: Buffer.from('en_US'),
+            });
+
+            wait(defs.ConnectionStartOk)()
+              .then(function (frame) {
+                assert.strictEqual(frame.fields.locale, 'en_US');
+                bothDone();
+                send(defs.ConnectionTune, {
+                  channelMax: 0,
+                  heartbeat: 0,
+                  frameMax: 0,
+                });
+              })
+              .then(wait(defs.ConnectionTuneOk))
+              .then(wait(defs.ConnectionOpen))
+              .then(function () {
+                send(defs.ConnectionOpenOk, {knownHosts: ''});
+              })
+              .catch(bothDone);
+          });
+        });
+      })
+      .listen(0);
+
+    connect('amqp://localhost:' + server.address().port + '?locale=en_US&locale=fr_FR', {}, function (err, connection) {
+      if (err) {
+        return bothDone(err);
+      }
+      connection.close();
       bothDone();
     });
   });


### PR DESCRIPTION
node24 has the following deprecation warning:

> [DEP0169] DeprecationWarning: `url.parse()` behavior is not standardized and prone to errors that have security implications. Use the WHATWG URL API instead. CVEs are not issued for `url.parse()` vulnerabilities.

cf. https://nodejs.org/docs/latest-v24.x/api/url.html#urlparseurlstring-parsequerystring-slashesdenotehost

There was an existing MR to replace `url-parse` but has been stale for ~4 years:
https://github.com/amqp-node/amqplib/pull/678/changes

## changes
- url parsing in `lib/connect.js` with WHATWG `URL`
- removed `url-parse` dependency
- updated `test/connect.js` accordingly

Following remarks from previous MR are addressed:

- protocol handling keeps expected `amqp:` / `amqps:`
- vhost derived from URL pathname (+ test)
- credentials parsing behaviour remains compatible (incl. encoded delimiters)
- query options (`heartbeat`, `frameMax`, etc.) with existing behaviour

## attention points
- malformed URL strings now throw `Invalid URL` from `new URL(...)` instead of being loosely parsed then rejected later. This is still a throw-on-bad-input outcome, just with a different error origin/message.
- object-style protocol is now slightly more permissive: `{ protocol: 'amqp:' }` works now whereas old logic would produce `amqp::` and fail. Not a breaking change.

## preserved compatibility
- duplicate query params match old `url-parse` behaviour: first value wins
- object-style config with empty protocol defaults to AMQP: `{ protocol: '' }` behaves like no protocol
- URL protocol normalization still supports missing trailing colon on object input (`amqp` becomes `amqp:`)
- credentials fallback behaviour is preserved: default to guest/guest only when both username and password are missing
- vhost handling remains the same shape: `pathname` stripped then decoded by `QS.unescape` in handshake frame generation
- new tests now explicitly lock the two compatibility points from above (empty protocol, duplicate query keys collapsed to first one)

## next?
I think we could switch to `URLSearchParams`, but it is a separate compatibility decision because behaviour can differ from `querystring.parse` (which is still supported by node)