### PR TITLE
Replace url-parse with WHATWG URL API

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -1,4 +1,4 @@
-const URL = require('url-parse');
+const { URL } = require('node:url');
 const QS = require('node:querystring');
 const net = require('node:net');
 const tls = require('node:tls');
@@ -124,14 +124,24 @@ function connect(url, socketOptions, openCallback) {
 
     fields = openFrames(url.vhost, config, sockopts.credentials || credentials.plain(user, pass), extraClientProperties);
   } else {
-    const parts = URL(url, true); // yes, parse the query string
-    const host = parts.hostname.replace(/^\[|\]$/g, '');
-    protocol = parts.protocol;
+    let parts;
+    try {
+      parts = new URL(url);
+    } catch (_e) {
+      parts = {};
+    }
+    const host = (parts.hostname || '').replace(/^\[|\]$/g, '');
+    protocol = parts.protocol || '';
     sockopts.host = host;
     if (!sockopts.servername && !net.isIP(host)) sockopts.servername = host;
     sockopts.port = parseInt(parts.port, 10) || (protocol === 'amqp:' ? 5672 : 5671);
     const vhost = parts.pathname ? parts.pathname.substr(1) : null;
-    fields = openFrames(vhost, parts.query, sockopts.credentials || credentialsFromUrl(parts), extraClientProperties);
+    const query = QS.parse(parts.search ? parts.search.slice(1) : '');
+    // QS.parse returns arrays for duplicate keys; match url-parse's first-value-wins behavior.
+    for (const key in query) {
+      if (Array.isArray(query[key])) query[key] = query[key][0];
+    }
+    fields = openFrames(vhost, query, sockopts.credentials || credentialsFromUrl(parts), extraClientProperties);
   }
 
   let sockok = false;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "buffer-more-ints": "~1.0.0",
-        "url-parse": "~1.5.10"
+        "buffer-more-ints": "~1.0.0"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.2.2",
@@ -486,11 +485,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
-    },
     "node_modules/repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
@@ -499,11 +493,6 @@
       "engines": {
         "node": ">=0.10"
       }
-    },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "node_modules/right-align": {
       "version": "0.1.3",
@@ -551,15 +540,6 @@
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "dev": true,
       "optional": true
-    },
-    "node_modules/url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
-      }
     },
     "node_modules/window-size": {
       "version": "0.1.0",
@@ -857,21 +837,11 @@
       "integrity": "sha1-z4JLS0fMc8vZb56YhQc7Q6rqqzs=",
       "dev": true
     },
-    "querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
-    },
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
-    },
-    "requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "right-align": {
       "version": "0.1.3",
@@ -907,15 +877,6 @@
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "dev": true,
       "optional": true
-    },
-    "url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "requires": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
-      }
     },
     "window-size": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "buffer-more-ints": "~1.0.0",
-    "url-parse": "~1.5.10"
+    "buffer-more-ints": "~1.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.2.2",


### PR DESCRIPTION
Removes the `url-parse` dependency and replaces it with the built-in WHATWG `URL` API (Node >= 18), resolving `DEP0169` deprecation warnings from Node 24.

Closes #834.