### PR TITLE
Fix memory leak in ConfirmChannel.publish when channel is closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Updated build to use RabbitMQ 4.2
+- Fix memory leak in ConfirmChannel.publish when channel is already closed (fixes #842)
 
 ## v1.0.3
 - Fix AssertionError crash when backpressure occurs while draining newStreams in Mux (fixes #841)

--- a/lib/callback_model.js
+++ b/lib/callback_model.js
@@ -246,8 +246,9 @@ function callbackWrapper(_ch, cb) {
 
 class ConfirmChannel extends Channel {
   publish(exchange, routingKey, content, options, cb) {
+    const result = Channel.prototype.publish.call(this, exchange, routingKey, content, options);
     this.pushConfirmCallback(cb);
-    return Channel.prototype.publish.call(this, exchange, routingKey, content, options);
+    return result;
   }
 
   sendToQueue(queue, content, options, cb) {

--- a/lib/channel_model.js
+++ b/lib/channel_model.js
@@ -224,8 +224,9 @@ Channel.prototype.prefetch = Channel.prototype.qos;
 
 class ConfirmChannel extends Channel {
   publish(exchange, routingKey, content, options, cb) {
+    const result = super.publish(exchange, routingKey, content, options);
     this.pushConfirmCallback(cb);
-    return super.publish(exchange, routingKey, content, options);
+    return result;
   }
 
   sendToQueue(queue, content, options, cb) {

--- a/test/callback_api.test.js
+++ b/test/callback_api.test.js
@@ -305,6 +305,17 @@ describe('Callback API', () => {
         done();
       });
     });
+
+    confirm_channel_test('publish on closed channel does not leak callbacks', (_ch, done) => {
+      ch = _ch;
+      ch.close(() => {
+        for (let i = 0; i < 10; i++) {
+          try { ch.publish('', '', Buffer.from('x'), {}, () => {}); } catch (_) {}
+        }
+        assert.strictEqual(ch.unconfirmed.length, 0);
+        done();
+      });
+    });
   });
 
   describe('Error handling', () => {

--- a/test/channel_api.test.js
+++ b/test/channel_api.test.js
@@ -499,6 +499,17 @@ describe('confirms', () => {
         }));
     });
   });
+
+  it('publish on closed channel does not leak callbacks', () => {
+    return withConfirmChannel((ch) => {
+      return ch.close().then(() => {
+        for (let i = 0; i < 10; i++) {
+          try { ch.publish('', '', Buffer.from('x'), {}, () => {}); } catch (_) {}
+        }
+        assert.strictEqual(ch.unconfirmed.length, 0);
+      });
+    });
+  });
 });
 
 function connect() {


### PR DESCRIPTION
Fixes #842

When `publish` was called on a closed `ConfirmChannel`, the callback was pushed into `this.unconfirmed` before `super.publish()` threw `IllegalOperationError`. Since the `'close'` event (which drains `unconfirmed`) had already fired, the callback leaked permanently — growing without bound on repeated calls.

The fix swaps the order: call `super.publish()` first, and only push the callback if it succeeds. The `IllegalOperationError` still throws on a closed channel; callers can catch it and handle their own callback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)