### PR TITLE
Fix: close connection immediately when blocked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - Updated build to use RabbitMQ 4.2
 - Fix memory leak in ConfirmChannel.publish when channel is already closed (fixes #842)
+- Close connection immediately when close() is called while the connection is blocked (fixes #744)
 
 ## v1.0.3
 - Fix AssertionError crash when backpressure occurs while draining newStreams in Mux (fixes #841)

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -41,6 +41,7 @@ class Connection extends EventEmitter {
     this.recvSinceLastCheck = false;
 
     this.expectSocketClose = false;
+    this.blocked = false;
     this.freeChannels = new BitSet();
     this.channels = [
       {
@@ -300,6 +301,13 @@ class Connection extends EventEmitter {
   // ignored. We also have to shut down all the channels.
   toClosing(capturedStack, k) {
     const send = this.sendMethod.bind(this);
+
+    if (this.blocked) {
+      if (k) k();
+      const s = stackCapture('Connection blocked: closing immediately');
+      this.toClosed(s, undefined);
+      return;
+    }
 
     this.accept = function (f) {
       if (f.id === defs.ConnectionCloseOk) {
@@ -581,8 +589,10 @@ function channel0(connection) {
       }
       connection.toClosed(s, e);
     } else if (f.id === defs.ConnectionBlocked) {
+      connection.blocked = true;
       connection.emit('blocked', f.fields.reason);
     } else if (f.id === defs.ConnectionUnblocked) {
+      connection.blocked = false;
       connection.emit('unblocked');
     } else if (f.id === defs.ConnectionUpdateSecretOk) {
       connection.emit('update-secret-ok');

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -278,6 +278,26 @@ describe('Connection', () => {
         .then(() => send(defs.ConnectionCloseOk, {}))
         .then(cb, cb);
     }));
+
+    it('close while blocked closes immediately', connectionTest((c, cb) => {
+      const decrementLatch = latch(2, cb);
+      c.on('close', () => decrementLatch());
+      c.open(OPEN_OPTS, (err) => {
+        assert.ifError(err);
+        c.once('blocked', () => {
+          c.close((err) => {
+            assert.ifError(err);
+            decrementLatch();
+          });
+        });
+      });
+    }, (send, wait, cb) => {
+      handshake(send, wait)
+        .then(() => send(defs.ConnectionBlocked, { reason: 'memory' }, 0))
+        .then(wait(defs.ConnectionClose))
+        // deliberately do NOT send ConnectionCloseOk — client must close anyway
+        .then(cb, cb);
+    }));
   });
 
   describe('heartbeats', () => {


### PR DESCRIPTION
When `connection.blocked` is received and `close()` is subsequently called, the client sends `ConnectionClose` then waits in `toClosing()` for a `ConnectionCloseOk`. RabbitMQ won't send that reply until the connection becomes unblocked, which may never happen — leaving the connection hanging open indefinitely.

This tracks the blocked state on the connection and short-circuits `toClosing()` to call `toClosed()` directly when the connection is blocked, closing immediately without waiting for the handshake.

Closes #744.