### PR TITLE
Fix: ConfirmChannel callbacks silently dropped on close when some publishes had no callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log for amqplib
 
+## Unreleased
+- Fix ConfirmChannel callbacks silently dropped on channel close when some publishes had no callback (fixes #191)
+
 ## v1.0.4
 - Updated build to use RabbitMQ 4.2
 - Fix memory leak in ConfirmChannel.publish when channel is already closed (fixes #842)

--- a/lib/channel.js
+++ b/lib/channel.js
@@ -33,11 +33,12 @@ class Channel extends EventEmitter {
       }),
     );
     this.on('close', function () {
-      let cb = this.unconfirmed.shift();
-      while (cb) {
-        if (cb) cb(new Error('channel closed'));
-        cb = this.unconfirmed.shift();
+      const err = new Error('channel closed');
+      for (let i = 0; i < this.unconfirmed.length; i++) {
+        const cb = this.unconfirmed[i];
+        if (cb) cb(err);
       }
+      this.unconfirmed = this.unconfirmed.filter((cb) => cb === false);
     });
     // message frame state machine
     this.handleMessage = acceptDeliveryOrReturn;

--- a/lib/channel_model.js
+++ b/lib/channel_model.js
@@ -236,11 +236,11 @@ class ConfirmChannel extends Channel {
   waitForConfirms() {
     const awaiting = [];
     const unconfirmed = this.unconfirmed;
-    unconfirmed.forEach((val, index) => {
-      if (val !== null) {
+    unconfirmed.forEach((cb, index) => {
+      if (cb !== null) {
         const confirmed = new Promise((resolve, reject) => {
           unconfirmed[index] = (err) => {
-            if (val) val(err);
+            if (cb) cb(err);
             if (err === null) resolve();
             else reject(err);
           };
@@ -250,10 +250,10 @@ class ConfirmChannel extends Channel {
     });
     // Channel closed
     if (!this.pending) {
-      let cb = this.unconfirmed.shift();
-      while (cb) {
-        if (cb) cb(new Error('channel closed'));
-        cb = this.unconfirmed.shift();
+      const err = new Error('channel closed');
+      while (unconfirmed.length > 0) {
+        const cb = unconfirmed.shift();
+        if (cb) cb(err);
       }
     }
     return Promise.all(awaiting);

--- a/test/channel.test.js
+++ b/test/channel.test.js
@@ -588,5 +588,25 @@ describe('Channel', () => {
         send(defs.BasicAck, { deliveryTag: 1, multiple: false }, ch);
       }, cb);
     }));
+
+    // Regression test for https://github.com/amqp-node/amqplib/issues/191
+    // pushConfirmCallback stores `false` for publishes with no callback.
+    // The close drain used `while (cb)` which stops at the first `false`,
+    // silently dropping all callbacks that follow it.
+    it('invokes all pending callbacks on close even when some publishes had no callback', channelTest((ch, cb) => {
+      let called = 0;
+      const countErr = (err) => { if (err) called++; };
+      ch.pushConfirmCallback(countErr); // tag = 1 — has callback
+      ch.pushConfirmCallback(null);     // tag = 2 — no callback, stored as `false`
+      ch.pushConfirmCallback(countErr); // tag = 3 — has callback, dropped by while(cb) bug
+      open(ch).then(() => {
+        ch.toClosed('test close');
+        completes(() => {
+          assert.equal(2, called);
+        }, cb);
+      }, cb);
+    }, (_send, _wait, cb) => {
+      cb();
+    }));
   });
 });


### PR DESCRIPTION
Fixes #191

`pushConfirmCallback` stores `false` for publishes with no callback (i.e. when using `waitForConfirms` instead of per-message callbacks). The `close` event drain used `while (cb)` which stops at the first `false` entry, silently dropping all callbacks queued after it.

Fixed by iterating the full array in the `close` handler, calling real callbacks, then filtering out called entries so `waitForConfirms` can still wrap the remaining `false` slots into rejecting promises.

Also tidied `waitForConfirms`: use the local `unconfirmed` reference consistently, and rename `val` to `cb` for clarity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)