### PR TITLE
Embed TypeScript type definitions into the package (#843)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,5 +47,8 @@ jobs:
 
       - run: echo 'HELO\n\n\n\n' | nc localhost 5672 | grep AMQP
 
+      # Check TypeScript types
+      - run: npm run typecheck
+
       # Run the tests
       - run: make test

--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,5 @@ scratch
 .travis.yml
 etc/
 coverage/
+tsconfig.types.json
+types/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log for amqplib
 
+## Unreleased
+- Add bundled TypeScript type definitions (fixes #843)
+
 ## v1.0.6
 - Fix channel.get() not invoking callback with error on channel close; previously only an error event was emitted (fixes #832). **Note:** if you use the callback API, ensure your channel.get() callbacks handle errors — they will now be invoked in error cases where previously they were not. If you use the promise API, the returned promise now rejects with a proper Error object (with .code, .classId and .methodId properties) rather than a raw close frame.
 

--- a/callback_api.d.ts
+++ b/callback_api.d.ts
@@ -12,66 +12,66 @@ import {
 export * from './lib/properties';
 
 export interface Connection extends events.EventEmitter {
-  close(callback?: (err: any) => void): void;
-  createChannel(callback: (err: any, channel: Channel) => void): Channel;
-  createChannel(options: ChannelOptions, callback: (err: any, channel: Channel) => void): Channel;
-  createConfirmChannel(callback: (err: any, confirmChannel: ConfirmChannel) => void): ConfirmChannel;
-  createConfirmChannel(options: ChannelOptions, callback: (err: any, confirmChannel: ConfirmChannel) => void): ConfirmChannel;
+  close(callback?: (err: Error) => void): void;
+  createChannel(callback: (err: Error, channel: Channel) => void): Channel;
+  createChannel(options: ChannelOptions, callback: (err: Error, channel: Channel) => void): Channel;
+  createConfirmChannel(callback: (err: Error, confirmChannel: ConfirmChannel) => void): ConfirmChannel;
+  createConfirmChannel(options: ChannelOptions, callback: (err: Error, confirmChannel: ConfirmChannel) => void): ConfirmChannel;
   readonly connection: {
     readonly serverProperties: ServerProperties;
   };
-  updateSecret(newSecret: Buffer, reason: string, callback?: (err: any) => void): void;
+  updateSecret(newSecret: Buffer, reason: string, callback?: (err: Error) => void): void;
 }
 
 export interface Channel extends events.EventEmitter {
   readonly connection: Connection;
 
-  close(callback?: (err: any) => void): void;
+  close(callback?: (err: Error) => void): void;
 
-  assertQueue(queue?: string, options?: Options.AssertQueue, callback?: (err: any, ok: Replies.AssertQueue) => void): void;
-  checkQueue(queue: string, callback?: (err: any, ok: Replies.AssertQueue) => void): void;
+  assertQueue(queue?: string, options?: Options.AssertQueue, callback?: (err: Error, ok: Replies.AssertQueue) => void): void;
+  checkQueue(queue: string, callback?: (err: Error, ok: Replies.AssertQueue) => void): void;
 
-  deleteQueue(queue: string, options?: Options.DeleteQueue, callback?: (err: any, ok: Replies.DeleteQueue) => void): void;
-  purgeQueue(queue: string, callback?: (err: any, ok: Replies.PurgeQueue) => void): void;
+  deleteQueue(queue: string, options?: Options.DeleteQueue, callback?: (err: Error, ok: Replies.DeleteQueue) => void): void;
+  purgeQueue(queue: string, callback?: (err: Error, ok: Replies.PurgeQueue) => void): void;
 
   bindQueue(
     queue: string,
     source: string,
     pattern: string,
     args?: any,
-    callback?: (err: any, ok: Replies.Empty) => void,
+    callback?: (err: Error, ok: Replies.Empty) => void,
   ): void;
   unbindQueue(
     queue: string,
     source: string,
     pattern: string,
     args?: any,
-    callback?: (err: any, ok: Replies.Empty) => void,
+    callback?: (err: Error, ok: Replies.Empty) => void,
   ): void;
 
   assertExchange(
     exchange: string,
     type: 'direct' | 'topic' | 'headers' | 'fanout' | 'match' | string,
     options?: Options.AssertExchange,
-    callback?: (err: any, ok: Replies.AssertExchange) => void,
+    callback?: (err: Error, ok: Replies.AssertExchange) => void,
   ): void;
-  checkExchange(exchange: string, callback?: (err: any, ok: Replies.Empty) => void): void;
+  checkExchange(exchange: string, callback?: (err: Error, ok: Replies.Empty) => void): void;
 
-  deleteExchange(exchange: string, options?: Options.DeleteExchange, callback?: (err: any, ok: Replies.Empty) => void): void;
+  deleteExchange(exchange: string, options?: Options.DeleteExchange, callback?: (err: Error, ok: Replies.Empty) => void): void;
 
   bindExchange(
     destination: string,
     source: string,
     pattern: string,
     args?: any,
-    callback?: (err: any, ok: Replies.Empty) => void,
+    callback?: (err: Error, ok: Replies.Empty) => void,
   ): void;
   unbindExchange(
     destination: string,
     source: string,
     pattern: string,
     args?: any,
-    callback?: (err: any, ok: Replies.Empty) => void,
+    callback?: (err: Error, ok: Replies.Empty) => void,
   ): void;
 
   publish(exchange: string, routingKey: string, content: Buffer, options?: Options.Publish): boolean;
@@ -81,11 +81,11 @@ export interface Channel extends events.EventEmitter {
     queue: string,
     onMessage: (msg: ConsumeMessage | null) => void,
     options?: Options.Consume,
-    callback?: (err: any, ok: Replies.Consume) => void,
+    callback?: (err: Error, ok: Replies.Consume) => void,
   ): void;
 
-  cancel(consumerTag: string, callback?: (err: any, ok: Replies.Empty) => void): void;
-  get(queue: string, options?: Options.Get, callback?: (err: any, ok: GetMessage | false) => void): void;
+  cancel(consumerTag: string, callback?: (err: Error, ok: Replies.Empty) => void): void;
+  get(queue: string, options?: Options.Get, callback?: (err: Error, ok: GetMessage | false) => void): void;
 
   ack(message: Message, allUpTo?: boolean): void;
   ackAll(): void;
@@ -94,8 +94,8 @@ export interface Channel extends events.EventEmitter {
   nackAll(requeue?: boolean): void;
   reject(message: Message, requeue?: boolean): void;
 
-  prefetch(count: number, global?: boolean, callback?: (err: any, ok: Replies.Empty) => void): void;
-  recover(callback?: (err: any, ok: Replies.Empty) => void): void;
+  prefetch(count: number, global?: boolean, callback?: (err: Error, ok: Replies.Empty) => void): void;
+  recover(callback?: (err: Error, ok: Replies.Empty) => void): void;
 }
 
 export interface ConfirmChannel extends Channel {
@@ -104,13 +104,13 @@ export interface ConfirmChannel extends Channel {
     routingKey: string,
     content: Buffer,
     options?: Options.Publish,
-    callback?: (err: any, ok: Replies.Empty) => void,
+    callback?: (err: Error, ok: Replies.Empty) => void,
   ): boolean;
   sendToQueue(
     queue: string,
     content: Buffer,
     options?: Options.Publish,
-    callback?: (err: any, ok: Replies.Empty) => void,
+    callback?: (err: Error, ok: Replies.Empty) => void,
   ): boolean;
 
   waitForConfirms(callback?: (err?: Error) => void): void;
@@ -141,10 +141,10 @@ export declare const credentials: {
   };
 };
 
-export declare function connect(callback: (err: any, connection: Connection) => void): void;
-export declare function connect(url: string | Options.Connect, callback: (err: any, connection: Connection) => void): void;
+export declare function connect(callback: (err: Error, connection: Connection) => void): void;
+export declare function connect(url: string | Options.Connect, callback: (err: Error, connection: Connection) => void): void;
 export declare function connect(
   url: string | Options.Connect,
   socketOptions: SocketOptions,
-  callback: (err: any, connection: Connection) => void,
+  callback: (err: Error, connection: Connection) => void,
 ): void;

--- a/callback_api.d.ts
+++ b/callback_api.d.ts
@@ -21,10 +21,29 @@ export interface Connection extends events.EventEmitter {
     readonly serverProperties: ServerProperties;
   };
   updateSecret(newSecret: Buffer, reason: string, callback?: (err: Error) => void): void;
+
+  on(event: 'close', listener: (err?: Error) => void): this;
+  on(event: 'error', listener: (err: Error) => void): this;
+  on(event: 'blocked', listener: (reason: string) => void): this;
+  on(event: 'unblocked', listener: () => void): this;
+  on(event: 'update-secret-ok', listener: () => void): this;
+  on(event: 'handler-error', listener: (err: Error, eventName: string) => void): this;
+  on(event: string, listener: (...args: any[]) => void): this;
 }
 
 export interface Channel extends events.EventEmitter {
   readonly connection: Connection;
+
+  on(event: 'close', listener: () => void): this;
+  on(event: 'error', listener: (err: Error) => void): this;
+  on(event: 'drain', listener: () => void): this;
+  on(event: 'ack', listener: (fields: { deliveryTag: number; multiple: boolean }) => void): this;
+  on(event: 'nack', listener: (fields: { deliveryTag: number; multiple: boolean; requeue: boolean }) => void): this;
+  on(event: 'cancel', listener: (fields: { consumerTag: string }) => void): this;
+  on(event: 'delivery', listener: (message: ConsumeMessage) => void): this;
+  on(event: 'return', listener: (message: Message) => void): this;
+  on(event: 'handler-error', listener: (err: Error, eventName: string) => void): this;
+  on(event: string, listener: (...args: any[]) => void): this;
 
   close(callback?: (err: Error) => void): void;
 

--- a/callback_api.d.ts
+++ b/callback_api.d.ts
@@ -1,0 +1,150 @@
+import events = require('events');
+import {
+  ChannelOptions,
+  ConsumeMessage,
+  GetMessage,
+  Message,
+  Options,
+  Replies,
+  ServerProperties,
+  SocketOptions,
+} from './lib/properties';
+export * from './lib/properties';
+
+export interface Connection extends events.EventEmitter {
+  close(callback?: (err: any) => void): void;
+  createChannel(callback: (err: any, channel: Channel) => void): Channel;
+  createChannel(options: ChannelOptions, callback: (err: any, channel: Channel) => void): Channel;
+  createConfirmChannel(callback: (err: any, confirmChannel: ConfirmChannel) => void): ConfirmChannel;
+  createConfirmChannel(options: ChannelOptions, callback: (err: any, confirmChannel: ConfirmChannel) => void): ConfirmChannel;
+  readonly connection: {
+    readonly serverProperties: ServerProperties;
+  };
+  updateSecret(newSecret: Buffer, reason: string, callback?: (err: any) => void): void;
+}
+
+export interface Channel extends events.EventEmitter {
+  readonly connection: Connection;
+
+  close(callback?: (err: any) => void): void;
+
+  assertQueue(queue?: string, options?: Options.AssertQueue, callback?: (err: any, ok: Replies.AssertQueue) => void): void;
+  checkQueue(queue: string, callback?: (err: any, ok: Replies.AssertQueue) => void): void;
+
+  deleteQueue(queue: string, options?: Options.DeleteQueue, callback?: (err: any, ok: Replies.DeleteQueue) => void): void;
+  purgeQueue(queue: string, callback?: (err: any, ok: Replies.PurgeQueue) => void): void;
+
+  bindQueue(
+    queue: string,
+    source: string,
+    pattern: string,
+    args?: any,
+    callback?: (err: any, ok: Replies.Empty) => void,
+  ): void;
+  unbindQueue(
+    queue: string,
+    source: string,
+    pattern: string,
+    args?: any,
+    callback?: (err: any, ok: Replies.Empty) => void,
+  ): void;
+
+  assertExchange(
+    exchange: string,
+    type: 'direct' | 'topic' | 'headers' | 'fanout' | 'match' | string,
+    options?: Options.AssertExchange,
+    callback?: (err: any, ok: Replies.AssertExchange) => void,
+  ): void;
+  checkExchange(exchange: string, callback?: (err: any, ok: Replies.Empty) => void): void;
+
+  deleteExchange(exchange: string, options?: Options.DeleteExchange, callback?: (err: any, ok: Replies.Empty) => void): void;
+
+  bindExchange(
+    destination: string,
+    source: string,
+    pattern: string,
+    args?: any,
+    callback?: (err: any, ok: Replies.Empty) => void,
+  ): void;
+  unbindExchange(
+    destination: string,
+    source: string,
+    pattern: string,
+    args?: any,
+    callback?: (err: any, ok: Replies.Empty) => void,
+  ): void;
+
+  publish(exchange: string, routingKey: string, content: Buffer, options?: Options.Publish): boolean;
+  sendToQueue(queue: string, content: Buffer, options?: Options.Publish): boolean;
+
+  consume(
+    queue: string,
+    onMessage: (msg: ConsumeMessage | null) => void,
+    options?: Options.Consume,
+    callback?: (err: any, ok: Replies.Consume) => void,
+  ): void;
+
+  cancel(consumerTag: string, callback?: (err: any, ok: Replies.Empty) => void): void;
+  get(queue: string, options?: Options.Get, callback?: (err: any, ok: GetMessage | false) => void): void;
+
+  ack(message: Message, allUpTo?: boolean): void;
+  ackAll(): void;
+
+  nack(message: Message, allUpTo?: boolean, requeue?: boolean): void;
+  nackAll(requeue?: boolean): void;
+  reject(message: Message, requeue?: boolean): void;
+
+  prefetch(count: number, global?: boolean, callback?: (err: any, ok: Replies.Empty) => void): void;
+  recover(callback?: (err: any, ok: Replies.Empty) => void): void;
+}
+
+export interface ConfirmChannel extends Channel {
+  publish(
+    exchange: string,
+    routingKey: string,
+    content: Buffer,
+    options?: Options.Publish,
+    callback?: (err: any, ok: Replies.Empty) => void,
+  ): boolean;
+  sendToQueue(
+    queue: string,
+    content: Buffer,
+    options?: Options.Publish,
+    callback?: (err: any, ok: Replies.Empty) => void,
+  ): boolean;
+
+  waitForConfirms(callback?: (err?: Error) => void): void;
+}
+
+export declare class IllegalOperationError extends Error {
+  name: 'IllegalOperationError';
+  stackAtStateChange: string | undefined;
+  constructor(msg: string, stack?: string);
+}
+
+export declare const credentials: {
+  plain(username: string, password: string): {
+    mechanism: string;
+    response(): Buffer;
+    username: string;
+    password: string;
+  };
+  amqplain(username: string, password: string): {
+    mechanism: string;
+    response(): Buffer;
+    username: string;
+    password: string;
+  };
+  external(): {
+    mechanism: string;
+    response(): Buffer;
+  };
+};
+
+export declare function connect(callback: (err: any, connection: Connection) => void): void;
+export declare function connect(url: string | Options.Connect, callback: (err: any, connection: Connection) => void): void;
+export declare function connect(
+  url: string | Options.Connect,
+  socketOptions: SocketOptions,
+  callback: (err: any, connection: Connection) => void,
+): void;

--- a/callback_api.d.ts
+++ b/callback_api.d.ts
@@ -141,6 +141,41 @@ export declare const credentials: {
   };
 };
 
+export interface RecoveryOptions {
+  /** Initial reconnect delay in milliseconds. Default: 100 */
+  initialDelay?: number;
+  /** Maximum reconnect delay in milliseconds. Default: 30000 */
+  maxDelay?: number;
+  /** Backoff multiplier applied to delay on each attempt. Default: 2 */
+  factor?: number;
+  /** Jitter factor (0–1) applied to delay to avoid thundering herd. Default: 0.2 */
+  jitter?: number;
+  /** Maximum number of reconnect attempts. Default: Infinity */
+  maxRetries?: number;
+  /** Optional setup function called after each successful connection */
+  setup?: ((model: Connection) => Promise<void>) | ((model: Connection, done: (err?: Error) => void) => void);
+}
+
+export interface RecoveringConnection extends events.EventEmitter {
+  close(callback?: (err: Error) => void): void;
+  createChannel(callback: (err: Error, channel: Channel) => void): Channel;
+  createChannel(options: ChannelOptions, callback: (err: Error, channel: Channel) => void): Channel;
+  createConfirmChannel(callback: (err: Error, confirmChannel: ConfirmChannel) => void): ConfirmChannel;
+  createConfirmChannel(options: ChannelOptions, callback: (err: Error, confirmChannel: ConfirmChannel) => void): ConfirmChannel;
+  updateSecret(newSecret: Buffer, reason: string, callback?: (err: Error) => void): void;
+
+  on(event: 'connect', listener: (model: Connection) => void): this;
+  on(event: 'disconnect', listener: (err: Error) => void): this;
+  on(event: 'connect-failed', listener: (err: Error) => void): this;
+  on(event: 'reconnect-scheduled', listener: (info: { attempt: number; delay: number; error: Error }) => void): this;
+  on(event: 'reconnect-failed', listener: (err: Error) => void): this;
+  on(event: 'blocked', listener: (reason: string) => void): this;
+  on(event: 'unblocked', listener: () => void): this;
+  on(event: 'error', listener: (err: Error) => void): this;
+  on(event: 'update-secret-ok', listener: () => void): this;
+  on(event: string, listener: (...args: any[]) => void): this;
+}
+
 export declare function connect(callback: (err: Error, connection: Connection) => void): void;
 export declare function connect(url: string | Options.Connect, callback: (err: Error, connection: Connection) => void): void;
 export declare function connect(
@@ -148,3 +183,8 @@ export declare function connect(
   socketOptions: SocketOptions,
   callback: (err: Error, connection: Connection) => void,
 ): void;
+export declare function connect(
+  url: string | Options.Connect,
+  socketOptions: SocketOptions & { recovery: RecoveryOptions | true },
+  callback: (err: Error, connection: RecoveringConnection) => void,
+): RecoveringConnection;

--- a/index.d.ts
+++ b/index.d.ts
@@ -115,4 +115,38 @@ export declare const credentials: {
   };
 };
 
+export interface RecoveryOptions {
+  /** Initial reconnect delay in milliseconds. Default: 100 */
+  initialDelay?: number;
+  /** Maximum reconnect delay in milliseconds. Default: 30000 */
+  maxDelay?: number;
+  /** Backoff multiplier applied to delay on each attempt. Default: 2 */
+  factor?: number;
+  /** Jitter factor (0–1) applied to delay to avoid thundering herd. Default: 0.2 */
+  jitter?: number;
+  /** Maximum number of reconnect attempts. Default: Infinity */
+  maxRetries?: number;
+  /** Optional setup function called after each successful connection */
+  setup?: ((model: ChannelModel) => Promise<void>) | ((model: ChannelModel, done: (err?: Error) => void) => void);
+}
+
+export interface RecoveringChannelModel extends events.EventEmitter {
+  close(): Promise<void>;
+  createChannel(options?: ChannelOptions): Promise<Channel>;
+  createConfirmChannel(options?: ChannelOptions): Promise<ConfirmChannel>;
+  updateSecret(newSecret: Buffer, reason: string): Promise<void>;
+
+  on(event: 'connect', listener: (model: ChannelModel) => void): this;
+  on(event: 'disconnect', listener: (err: Error) => void): this;
+  on(event: 'connect-failed', listener: (err: Error) => void): this;
+  on(event: 'reconnect-scheduled', listener: (info: { attempt: number; delay: number; error: Error }) => void): this;
+  on(event: 'reconnect-failed', listener: (err: Error) => void): this;
+  on(event: 'blocked', listener: (reason: string) => void): this;
+  on(event: 'unblocked', listener: () => void): this;
+  on(event: 'error', listener: (err: Error) => void): this;
+  on(event: 'update-secret-ok', listener: () => void): this;
+  on(event: string, listener: (...args: any[]) => void): this;
+}
+
 export declare function connect(url: string | Options.Connect, socketOptions?: SocketOptions): Promise<ChannelModel>;
+export declare function connect(url: string | Options.Connect, socketOptions: SocketOptions & { recovery: RecoveryOptions | true }): Promise<RecoveringChannelModel>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,118 @@
+import events = require('events');
+import {
+  ChannelOptions,
+  ConsumeMessage,
+  GetMessage,
+  Message,
+  Options,
+  Replies,
+  ServerProperties,
+  SocketOptions,
+} from './lib/properties';
+export * from './lib/properties';
+
+export interface Connection {
+  readonly serverProperties: ServerProperties;
+}
+
+export interface ChannelModel extends events.EventEmitter {
+  close(): Promise<void>;
+  createChannel(options?: ChannelOptions): Promise<Channel>;
+  createConfirmChannel(options?: ChannelOptions): Promise<ConfirmChannel>;
+  readonly connection: Connection;
+  updateSecret(newSecret: Buffer, reason: string): Promise<void>;
+}
+
+export interface Channel extends events.EventEmitter {
+  readonly connection: Connection;
+
+  close(): Promise<void>;
+
+  assertQueue(queue?: string, options?: Options.AssertQueue): Promise<Replies.AssertQueue>;
+  checkQueue(queue: string): Promise<Replies.AssertQueue>;
+
+  deleteQueue(queue: string, options?: Options.DeleteQueue): Promise<Replies.DeleteQueue>;
+  purgeQueue(queue: string): Promise<Replies.PurgeQueue>;
+
+  bindQueue(queue: string, source: string, pattern: string, args?: any): Promise<Replies.Empty>;
+  unbindQueue(queue: string, source: string, pattern: string, args?: any): Promise<Replies.Empty>;
+
+  assertExchange(
+    exchange: string,
+    type: 'direct' | 'topic' | 'headers' | 'fanout' | 'match' | string,
+    options?: Options.AssertExchange,
+  ): Promise<Replies.AssertExchange>;
+  checkExchange(exchange: string): Promise<Replies.Empty>;
+
+  deleteExchange(exchange: string, options?: Options.DeleteExchange): Promise<Replies.Empty>;
+
+  bindExchange(destination: string, source: string, pattern: string, args?: any): Promise<Replies.Empty>;
+  unbindExchange(destination: string, source: string, pattern: string, args?: any): Promise<Replies.Empty>;
+
+  publish(exchange: string, routingKey: string, content: Buffer, options?: Options.Publish): boolean;
+  sendToQueue(queue: string, content: Buffer, options?: Options.Publish): boolean;
+
+  consume(
+    queue: string,
+    onMessage: (msg: ConsumeMessage | null) => void,
+    options?: Options.Consume,
+  ): Promise<Replies.Consume>;
+
+  cancel(consumerTag: string): Promise<Replies.Empty>;
+  get(queue: string, options?: Options.Get): Promise<GetMessage | false>;
+
+  ack(message: Message, allUpTo?: boolean): void;
+  ackAll(): void;
+
+  nack(message: Message, allUpTo?: boolean, requeue?: boolean): void;
+  nackAll(requeue?: boolean): void;
+  reject(message: Message, requeue?: boolean): void;
+
+  prefetch(count: number, global?: boolean): Promise<Replies.Empty>;
+  recover(): Promise<Replies.Empty>;
+}
+
+export interface ConfirmChannel extends Channel {
+  publish(
+    exchange: string,
+    routingKey: string,
+    content: Buffer,
+    options?: Options.Publish,
+    callback?: (err: any, ok: Replies.Empty) => void,
+  ): boolean;
+  sendToQueue(
+    queue: string,
+    content: Buffer,
+    options?: Options.Publish,
+    callback?: (err: any, ok: Replies.Empty) => void,
+  ): boolean;
+
+  waitForConfirms(): Promise<void>;
+}
+
+export declare class IllegalOperationError extends Error {
+  name: 'IllegalOperationError';
+  stackAtStateChange: string | undefined;
+  constructor(msg: string, stack?: string);
+}
+
+export declare const credentials: {
+  plain(username: string, password: string): {
+    mechanism: string;
+    response(): Buffer;
+    username: string;
+    password: string;
+  };
+  amqplain(username: string, password: string): {
+    mechanism: string;
+    response(): Buffer;
+    username: string;
+    password: string;
+  };
+  external(): {
+    mechanism: string;
+    response(): Buffer;
+  };
+};
+
+export declare function connect(url: string | Options.Connect, socketOptions?: SocketOptions): Promise<ChannelModel>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -45,7 +45,6 @@ export interface Channel extends events.EventEmitter {
   on(event: 'handler-error', listener: (err: Error, eventName: string) => void): this;
   on(event: string, listener: (...args: any[]) => void): this;
 
-
   close(): Promise<void>;
 
   assertQueue(queue?: string, options?: Options.AssertQueue): Promise<Replies.AssertQueue>;
@@ -168,5 +167,5 @@ export interface RecoveringChannelModel extends events.EventEmitter {
   on(event: string, listener: (...args: any[]) => void): this;
 }
 
-export declare function connect(url: string | Options.Connect, socketOptions?: SocketOptions): Promise<ChannelModel>;
 export declare function connect(url: string | Options.Connect, socketOptions: SocketOptions & { recovery: RecoveryOptions | true }): Promise<RecoveringChannelModel>;
+export declare function connect(url: string | Options.Connect, socketOptions?: SocketOptions): Promise<ChannelModel>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,10 +21,30 @@ export interface ChannelModel extends events.EventEmitter {
   createConfirmChannel(options?: ChannelOptions): Promise<ConfirmChannel>;
   readonly connection: Connection;
   updateSecret(newSecret: Buffer, reason: string): Promise<void>;
+
+  on(event: 'close', listener: (err?: Error) => void): this;
+  on(event: 'error', listener: (err: Error) => void): this;
+  on(event: 'blocked', listener: (reason: string) => void): this;
+  on(event: 'unblocked', listener: () => void): this;
+  on(event: 'update-secret-ok', listener: () => void): this;
+  on(event: 'handler-error', listener: (err: Error, eventName: string) => void): this;
+  on(event: string, listener: (...args: any[]) => void): this;
 }
 
 export interface Channel extends events.EventEmitter {
   readonly connection: Connection;
+
+  on(event: 'close', listener: () => void): this;
+  on(event: 'error', listener: (err: Error) => void): this;
+  on(event: 'drain', listener: () => void): this;
+  on(event: 'ack', listener: (fields: { deliveryTag: number; multiple: boolean }) => void): this;
+  on(event: 'nack', listener: (fields: { deliveryTag: number; multiple: boolean; requeue: boolean }) => void): this;
+  on(event: 'cancel', listener: (fields: { consumerTag: string }) => void): this;
+  on(event: 'delivery', listener: (message: ConsumeMessage) => void): this;
+  on(event: 'return', listener: (message: Message) => void): this;
+  on(event: 'handler-error', listener: (err: Error, eventName: string) => void): this;
+  on(event: string, listener: (...args: any[]) => void): this;
+
 
   close(): Promise<void>;
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -10,5 +10,8 @@ pre-commit:
       glob: "**/*.js"
       run: npx biome lint {staged_files} --write
       stage_fixed: true
+    typecheck:
+      glob: "{**/*.d.ts,types/*.ts}"
+      run: npm run typecheck
     test:
       run: npm test

--- a/lib/properties.d.ts
+++ b/lib/properties.d.ts
@@ -1,0 +1,208 @@
+import * as tls from 'tls';
+
+export namespace Replies {
+  interface Empty {}
+  interface AssertQueue {
+    queue: string;
+    messageCount: number;
+    consumerCount: number;
+  }
+  interface PurgeQueue {
+    messageCount: number;
+  }
+  interface DeleteQueue {
+    messageCount: number;
+  }
+  interface AssertExchange {
+    exchange: string;
+  }
+  interface Consume {
+    consumerTag: string;
+  }
+}
+
+export namespace Options {
+  interface Connect {
+    protocol?: string;
+    hostname?: string;
+    port?: number;
+    username?: string;
+    password?: string;
+    locale?: string;
+    frameMax?: number;
+    heartbeat?: number;
+    vhost?: string;
+    channelMax?: number;
+    credentials?: {
+      mechanism: string;
+      response(): Buffer;
+      username?: string;
+      password?: string;
+    };
+  }
+
+  interface AssertQueue {
+    exclusive?: boolean;
+    durable?: boolean;
+    autoDelete?: boolean;
+    arguments?: any;
+    messageTtl?: number;
+    expires?: number;
+    deadLetterExchange?: string;
+    deadLetterRoutingKey?: string;
+    maxLength?: number;
+    maxPriority?: number;
+    overflow?: string;
+    queueMode?: string;
+  }
+
+  interface DeleteQueue {
+    ifUnused?: boolean;
+    ifEmpty?: boolean;
+  }
+
+  interface AssertExchange {
+    durable?: boolean;
+    internal?: boolean;
+    autoDelete?: boolean;
+    alternateExchange?: string;
+    arguments?: any;
+  }
+
+  interface DeleteExchange {
+    ifUnused?: boolean;
+  }
+
+  interface Publish {
+    expiration?: string | number;
+    userId?: string;
+    CC?: string | string[];
+    mandatory?: boolean;
+    persistent?: boolean;
+    deliveryMode?: boolean | number;
+    BCC?: string | string[];
+    contentType?: string;
+    contentEncoding?: string;
+    headers?: any;
+    priority?: number;
+    correlationId?: string;
+    replyTo?: string;
+    messageId?: string;
+    timestamp?: number;
+    type?: string;
+    appId?: string;
+  }
+
+  interface Consume {
+    consumerTag?: string;
+    noLocal?: boolean;
+    noAck?: boolean;
+    exclusive?: boolean;
+    priority?: number;
+    arguments?: any;
+  }
+
+  interface Get {
+    noAck?: boolean;
+  }
+}
+
+export interface SocketOptions extends tls.ConnectionOptions {
+  noDelay?: boolean;
+  timeout?: number;
+  keepAlive?: boolean;
+  keepAliveDelay?: number;
+  clientProperties?: Record<string, unknown>;
+  credentials?: {
+    mechanism: string;
+    response(): Buffer;
+    username?: string;
+    password?: string;
+  };
+}
+
+export interface ChannelOptions {
+  highWaterMark?: number;
+}
+
+export interface Message {
+  content: Buffer;
+  fields: MessageFields;
+  properties: MessageProperties;
+}
+
+export interface GetMessage extends Message {
+  fields: GetMessageFields;
+}
+
+export interface ConsumeMessage extends Message {
+  fields: ConsumeMessageFields;
+}
+
+export interface CommonMessageFields {
+  deliveryTag: number;
+  redelivered: boolean;
+  exchange: string;
+  routingKey: string;
+}
+
+export interface MessageFields extends CommonMessageFields {
+  messageCount?: number;
+  consumerTag?: string;
+}
+
+export interface GetMessageFields extends CommonMessageFields {
+  messageCount: number;
+}
+
+export interface ConsumeMessageFields extends CommonMessageFields {
+  consumerTag: string;
+}
+
+export interface MessageProperties {
+  contentType: any | undefined;
+  contentEncoding: any | undefined;
+  headers: MessagePropertyHeaders | undefined;
+  deliveryMode: any | undefined;
+  priority: any | undefined;
+  correlationId: any | undefined;
+  replyTo: any | undefined;
+  expiration: any | undefined;
+  messageId: any | undefined;
+  timestamp: any | undefined;
+  type: any | undefined;
+  userId: any | undefined;
+  appId: any | undefined;
+  clusterId: any | undefined;
+}
+
+export interface MessagePropertyHeaders {
+  'x-first-death-exchange'?: string;
+  'x-first-death-queue'?: string;
+  'x-first-death-reason'?: string;
+  'x-death'?: XDeath[];
+  [key: string]: any;
+}
+
+export interface XDeath {
+  count: number;
+  reason: 'rejected' | 'expired' | 'maxlen';
+  queue: string;
+  time: {
+    '!': 'timestamp';
+    value: number;
+  };
+  exchange: string;
+  'original-expiration'?: any;
+  'routing-keys': string[];
+}
+
+export interface ServerProperties {
+  host: string;
+  product: string;
+  version: string;
+  platform: string;
+  copyright?: string;
+  information: string;
+  [key: string]: string | undefined;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,10 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.2.2",
+        "@types/node": "^25.6.0",
         "claire": "0.4.1",
         "lefthook": "^1.12.3",
+        "typescript": "^5.9.3",
         "uglify-js": "2.8.x"
       },
       "engines": {
@@ -182,6 +184,16 @@
       ],
       "engines": {
         "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/align-text": {
@@ -506,6 +518,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/uglify-js": {
       "version": "2.8.29",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
@@ -540,6 +566,13 @@
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "dev": true,
       "optional": true
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/window-size": {
       "version": "0.1.0",
@@ -635,6 +668,15 @@
       "integrity": "sha512-DAuHhHekGfiGb6lCcsT4UyxQmVwQiBCBUMwVra/dcOSs9q8OhfaZgey51MlekT3p8UwRqtXQfFuEJBhJNdLZwg==",
       "dev": true,
       "optional": true
+    },
+    "@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~7.19.0"
+      }
     },
     "align-text": {
       "version": "0.1.4",
@@ -852,6 +894,12 @@
         "align-text": "^0.1.1"
       }
     },
+    "typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true
+    },
     "uglify-js": {
       "version": "2.8.29",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
@@ -877,6 +925,12 @@
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "dev": true,
       "optional": true
+    },
+    "undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true
     },
     "window-size": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,17 @@
   "homepage": "http://amqp-node.github.io/amqplib/",
   "main": "./channel_api.js",
   "version": "1.0.6",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./channel_api.js"
+    },
+    "./callback_api": {
+      "types": "./callback_api.d.ts",
+      "default": "./callback_api.js"
+    }
+  },
   "description": "An AMQP 0-9-1 (e.g., RabbitMQ) library and client.",
   "repository": {
     "type": "git",
@@ -16,8 +27,10 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.2.2",
+    "@types/node": "^25.6.0",
     "claire": "0.4.1",
     "lefthook": "^1.12.3",
+    "typescript": "^5.9.3",
     "uglify-js": "2.8.x"
   },
   "scripts": {
@@ -26,7 +39,8 @@
     "rabbitmq-3": "docker run -d --rm --name rabbitmq -p 5672:5672 rabbitmq:3.12-alpine",
     "rabbitmq-4": "docker run -d --rm --name rabbitmq -p 5672:5672 rabbitmq:4.2-alpine",
     "format": "biome format . --write",
-    "lint": "biome lint --max-diagnostics=1000 ."
+    "lint": "biome lint --max-diagnostics=1000 .",
+    "typecheck": "tsc --noEmit -p tsconfig.types.json"
   },
   "keywords": [
     "AMQP",

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noEmit": true,
+    "moduleResolution": "node",
+    "module": "commonjs",
+    "target": "ES2020",
+    "skipLibCheck": false,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": [
+    "index.d.ts",
+    "callback_api.d.ts",
+    "lib/properties.d.ts",
+    "types/*.ts"
+  ]
+}

--- a/types/callback_api.ts
+++ b/types/callback_api.ts
@@ -184,6 +184,41 @@ function testIllegalOperationError() {
   const _stack: string | undefined = err.stackAtStateChange;
 }
 
+function testConnectionEvents(conn: amqp.Connection) {
+  conn.on('close', () => {});
+  conn.on('close', (err) => { const _e: Error | undefined = err; });
+  conn.on('error', (err) => { const _e: Error = err; });
+  conn.on('blocked', (reason) => { const _r: string = reason; });
+  conn.on('unblocked', () => {});
+  conn.on('update-secret-ok', () => {});
+  conn.on('handler-error', (err, eventName) => {
+    const _e: Error = err;
+    const _n: string = eventName;
+  });
+}
+
+function testChannelEvents(ch: amqp.Channel) {
+  ch.on('close', () => {});
+  ch.on('error', (err) => { const _e: Error = err; });
+  ch.on('drain', () => {});
+  ch.on('ack', (fields) => {
+    const _tag: number = fields.deliveryTag;
+    const _multiple: boolean = fields.multiple;
+  });
+  ch.on('nack', (fields) => {
+    const _tag: number = fields.deliveryTag;
+    const _multiple: boolean = fields.multiple;
+    const _requeue: boolean = fields.requeue;
+  });
+  ch.on('cancel', (fields) => { const _tag: string = fields.consumerTag; });
+  ch.on('delivery', (msg) => { const _content: Buffer = msg.content; });
+  ch.on('return', (msg) => { const _content: Buffer = msg.content; });
+  ch.on('handler-error', (err, eventName) => {
+    const _e: Error = err;
+    const _n: string = eventName;
+  });
+}
+
 function testRecovery() {
   const recoveryOpts: amqp.RecoveryOptions = {
     initialDelay: 100,

--- a/types/callback_api.ts
+++ b/types/callback_api.ts
@@ -183,3 +183,65 @@ function testIllegalOperationError() {
   const _name: 'IllegalOperationError' = err.name;
   const _stack: string | undefined = err.stackAtStateChange;
 }
+
+function testRecovery() {
+  const recoveryOpts: amqp.RecoveryOptions = {
+    initialDelay: 100,
+    maxDelay: 30000,
+    factor: 2,
+    jitter: 0.2,
+    maxRetries: 10,
+    setup: (model, done) => {
+      model.createChannel((err, _ch) => done(err ?? undefined));
+    },
+  };
+
+  const sockOpts: SocketOptions = { noDelay: true };
+
+  // connect with recovery enabled via boolean
+  const conn1: amqp.RecoveringConnection = amqp.connect('amqp://localhost', {
+    ...sockOpts,
+    recovery: true,
+  }, (err, conn) => {
+    if (err) return;
+    const _conn: amqp.RecoveringConnection = conn;
+  });
+
+  // connect with recovery options
+  const conn2: amqp.RecoveringConnection = amqp.connect('amqp://localhost', {
+    ...sockOpts,
+    recovery: recoveryOpts,
+  }, (err, conn) => {
+    if (err) return;
+    const _conn: amqp.RecoveringConnection = conn;
+  });
+
+  // RecoveringConnection supports same channel operations
+  conn1.createChannel((err, ch) => {
+    if (err) return;
+    const _ch: amqp.Channel = ch;
+  });
+  conn1.createConfirmChannel((err, ch) => {
+    if (err) return;
+    const _ch: amqp.ConfirmChannel = ch;
+  });
+  conn1.updateSecret(Buffer.from('secret'), 'rotation');
+  conn1.close();
+
+  // Recovery-specific events
+  conn2.on('connect', (model) => { const _m: amqp.Connection = model; });
+  conn2.on('disconnect', (err) => { const _e: Error = err; });
+  conn2.on('connect-failed', (err) => { const _e: Error = err; });
+  conn2.on('reconnect-scheduled', (info) => {
+    const _attempt: number = info.attempt;
+    const _delay: number = info.delay;
+    const _err: Error = info.error;
+  });
+  conn2.on('reconnect-failed', (err) => { const _e: Error = err; });
+  conn2.on('blocked', (reason) => { const _r: string = reason; });
+  conn2.on('unblocked', () => {});
+  conn2.on('error', (err) => { const _e: Error = err; });
+  conn2.on('update-secret-ok', () => {});
+
+  void [conn1, conn2];
+}

--- a/types/callback_api.ts
+++ b/types/callback_api.ts
@@ -1,0 +1,185 @@
+// Type-level tests for the callback API.
+// These are checked by `tsc --noEmit` but never executed at runtime.
+
+import * as amqp from '../callback_api';
+import { Options, SocketOptions } from '../lib/properties';
+
+function testConnectOverloads() {
+  // Overload 1: connect(callback)
+  amqp.connect((err, conn) => {
+    if (err) return;
+    const _conn: amqp.Connection = conn;
+  });
+
+  // Overload 2: connect(url, callback)
+  amqp.connect('amqp://localhost', (err, conn) => {
+    if (err) return;
+    const _conn: amqp.Connection = conn;
+  });
+
+  // Overload 2 with Options.Connect object
+  const opts: Options.Connect = { hostname: 'localhost', port: 5672 };
+  amqp.connect(opts, (err, conn) => {
+    if (err) return;
+    const _conn: amqp.Connection = conn;
+  });
+
+  // Overload 3: connect(url, socketOptions, callback)
+  const sockOpts: SocketOptions = {
+    noDelay: true,
+    rejectUnauthorized: false,
+  };
+  amqp.connect('amqps://localhost', sockOpts, (err, conn) => {
+    if (err) return;
+    const _conn: amqp.Connection = conn;
+  });
+}
+
+function testConnection(conn: amqp.Connection) {
+  // serverProperties lives on conn.connection.serverProperties
+  const _serverProps: amqp.ServerProperties = conn.connection.serverProperties;
+
+  // createChannel — callback only
+  conn.createChannel((err, ch) => {
+    if (err) return;
+    const _ch: amqp.Channel = ch;
+  });
+
+  // createChannel — with options
+  conn.createChannel({ highWaterMark: 1024 }, (err, ch) => {
+    if (err) return;
+    const _ch: amqp.Channel = ch;
+  });
+
+  // createConfirmChannel — callback only
+  conn.createConfirmChannel((err, ch) => {
+    if (err) return;
+    const _ch: amqp.ConfirmChannel = ch;
+  });
+
+  // createConfirmChannel — with options
+  conn.createConfirmChannel({ highWaterMark: 512 }, (err, ch) => {
+    if (err) return;
+    const _ch: amqp.ConfirmChannel = ch;
+  });
+
+  conn.updateSecret(Buffer.from('newsecret'), 'rotation');
+  conn.close();
+  conn.close((err) => { void err; });
+}
+
+function testChannel(ch: amqp.Channel) {
+  // assertQueue — queue name is optional (server-named queues)
+  ch.assertQueue();
+  ch.assertQueue('');
+  ch.assertQueue('myqueue', { durable: true });
+  ch.assertQueue('myqueue', { durable: true }, (err, ok) => {
+    if (err) return;
+    const _name: string = ok.queue;
+    const _count: number = ok.messageCount;
+  });
+
+  // overflow and queueMode options
+  ch.assertQueue('q', { overflow: 'reject-publish', queueMode: 'lazy' });
+
+  ch.checkQueue('q', (err, ok) => {
+    if (err) return;
+    const _name: string = ok.queue;
+  });
+
+  ch.deleteQueue('q', {}, (err, ok) => {
+    if (err) return;
+    const _count: number = ok.messageCount;
+  });
+
+  ch.purgeQueue('q', (err, ok) => {
+    if (err) return;
+    const _count: number = ok.messageCount;
+  });
+
+  ch.bindQueue('q', 'ex', 'rk');
+  ch.unbindQueue('q', 'ex', 'rk');
+
+  ch.assertExchange('ex', 'direct', { durable: true }, (err, ok) => {
+    if (err) return;
+    const _name: string = ok.exchange;
+  });
+  ch.assertExchange('ex', 'topic');
+  ch.assertExchange('ex', 'x-custom'); // still valid via `string`
+
+  ch.checkExchange('ex');
+  ch.deleteExchange('ex', { ifUnused: false });
+
+  ch.bindExchange('dest', 'src', 'rk');
+  ch.unbindExchange('dest', 'src', 'rk');
+
+  // publish / sendToQueue
+  const _pub: boolean = ch.publish('ex', 'rk', Buffer.from('hello'), { persistent: true });
+  const _sent: boolean = ch.sendToQueue('q', Buffer.from('hi'));
+
+  // consume
+  ch.consume('q', (msg) => {
+    if (msg !== null) {
+      const _content: Buffer = msg.content;
+      const _tag: string = msg.fields.consumerTag;
+      ch.ack(msg);
+    }
+  }, { noAck: false }, (err, ok) => {
+    if (err) return;
+    const _tag: string = ok.consumerTag;
+  });
+
+  ch.cancel('tag');
+  ch.cancel('tag', (err, ok) => {
+    void [err, ok];
+  });
+
+  // get
+  ch.get('q', { noAck: false }, (err, msg) => {
+    if (err) return;
+    if (msg !== false) {
+      const _content: Buffer = msg.content;
+      const _count: number = msg.fields.messageCount;
+    }
+  });
+
+  const fakeMsg = {} as amqp.Message;
+  ch.ack(fakeMsg);
+  ch.ackAll();
+  ch.nack(fakeMsg, false, true);
+  ch.nackAll(true);
+  ch.reject(fakeMsg, false);
+
+  ch.prefetch(10);
+  ch.prefetch(10, false, (err, ok) => { void [err, ok]; });
+  ch.recover();
+  ch.recover((err, ok) => { void [err, ok]; });
+
+  ch.close();
+}
+
+function testConfirmChannel(ch: amqp.ConfirmChannel) {
+  ch.publish('ex', 'rk', Buffer.from('hello'), {}, (err, _ok) => {
+    if (err) console.error(err);
+  });
+  ch.sendToQueue('q', Buffer.from('hello'), {}, (err, _ok) => {
+    if (err) console.error(err);
+  });
+  ch.waitForConfirms();
+  ch.waitForConfirms((err) => { void err; });
+}
+
+function testCredentials() {
+  const plain = amqp.credentials.plain('user', 'pass');
+  const _mech: string = plain.mechanism;
+  const _resp: Buffer = plain.response();
+
+  const external = amqp.credentials.external();
+  const _mech2: string = external.mechanism;
+}
+
+function testIllegalOperationError() {
+  const err = new amqp.IllegalOperationError('channel closed');
+  const _name: 'IllegalOperationError' = err.name;
+  const _stack: string | undefined = err.stackAtStateChange;
+}

--- a/types/channel_api.ts
+++ b/types/channel_api.ts
@@ -228,13 +228,13 @@ async function testRecovery() {
 
   const sockOpts: SocketOptions = { noDelay: true };
 
-  // connect with recovery enabled via boolean
+  // connect with recovery enabled via boolean (direct object literal)
   const conn1: amqp.RecoveringChannelModel = await amqp.connect('amqp://localhost', {
-    ...sockOpts,
+    noDelay: true,
     recovery: true,
   });
 
-  // connect with recovery options
+  // connect with recovery options (spread from typed variable)
   const conn2: amqp.RecoveringChannelModel = await amqp.connect('amqp://localhost', {
     ...sockOpts,
     recovery: recoveryOpts,

--- a/types/channel_api.ts
+++ b/types/channel_api.ts
@@ -179,6 +179,41 @@ function testReExports() {
   const _getOpts: Options.Get = { noAck: true };
 }
 
+function testChannelModelEvents(conn: amqp.ChannelModel) {
+  conn.on('close', () => {});
+  conn.on('close', (err) => { const _e: Error | undefined = err; });
+  conn.on('error', (err) => { const _e: Error = err; });
+  conn.on('blocked', (reason) => { const _r: string = reason; });
+  conn.on('unblocked', () => {});
+  conn.on('update-secret-ok', () => {});
+  conn.on('handler-error', (err, eventName) => {
+    const _e: Error = err;
+    const _n: string = eventName;
+  });
+}
+
+function testChannelEvents(ch: amqp.Channel) {
+  ch.on('close', () => {});
+  ch.on('error', (err) => { const _e: Error = err; });
+  ch.on('drain', () => {});
+  ch.on('ack', (fields) => {
+    const _tag: number = fields.deliveryTag;
+    const _multiple: boolean = fields.multiple;
+  });
+  ch.on('nack', (fields) => {
+    const _tag: number = fields.deliveryTag;
+    const _multiple: boolean = fields.multiple;
+    const _requeue: boolean = fields.requeue;
+  });
+  ch.on('cancel', (fields) => { const _tag: string = fields.consumerTag; });
+  ch.on('delivery', (msg) => { const _content: Buffer = msg.content; });
+  ch.on('return', (msg) => { const _content: Buffer = msg.content; });
+  ch.on('handler-error', (err, eventName) => {
+    const _e: Error = err;
+    const _n: string = eventName;
+  });
+}
+
 async function testRecovery() {
   const recoveryOpts: amqp.RecoveryOptions = {
     initialDelay: 100,

--- a/types/channel_api.ts
+++ b/types/channel_api.ts
@@ -178,3 +178,54 @@ function testReExports() {
   const _opts: Options.Publish = { persistent: true };
   const _getOpts: Options.Get = { noAck: true };
 }
+
+async function testRecovery() {
+  const recoveryOpts: amqp.RecoveryOptions = {
+    initialDelay: 100,
+    maxDelay: 30000,
+    factor: 2,
+    jitter: 0.2,
+    maxRetries: 10,
+    setup: async (model: amqp.ChannelModel) => {
+      const _ch: amqp.Channel = await model.createChannel();
+    },
+  };
+
+  const sockOpts: SocketOptions = { noDelay: true };
+
+  // connect with recovery enabled via boolean
+  const conn1: amqp.RecoveringChannelModel = await amqp.connect('amqp://localhost', {
+    ...sockOpts,
+    recovery: true,
+  });
+
+  // connect with recovery options
+  const conn2: amqp.RecoveringChannelModel = await amqp.connect('amqp://localhost', {
+    ...sockOpts,
+    recovery: recoveryOpts,
+  });
+
+  // RecoveringChannelModel supports same channel operations
+  const ch: amqp.Channel = await conn1.createChannel();
+  const confirmCh: amqp.ConfirmChannel = await conn1.createConfirmChannel();
+  await conn1.updateSecret(Buffer.from('secret'), 'rotation');
+  void [ch, confirmCh];
+
+  // Recovery-specific events
+  conn2.on('connect', (model) => { const _m: amqp.ChannelModel = model; });
+  conn2.on('disconnect', (err) => { const _e: Error = err; });
+  conn2.on('connect-failed', (err) => { const _e: Error = err; });
+  conn2.on('reconnect-scheduled', (info) => {
+    const _attempt: number = info.attempt;
+    const _delay: number = info.delay;
+    const _err: Error = info.error;
+  });
+  conn2.on('reconnect-failed', (err) => { const _e: Error = err; });
+  conn2.on('blocked', (reason) => { const _r: string = reason; });
+  conn2.on('unblocked', () => {});
+  conn2.on('error', (err) => { const _e: Error = err; });
+  conn2.on('update-secret-ok', () => {});
+
+  await conn1.close();
+  await conn2.close();
+}

--- a/types/channel_api.ts
+++ b/types/channel_api.ts
@@ -1,0 +1,180 @@
+// Type-level tests for the promise (channel) API.
+// These are checked by `tsc --noEmit` but never executed at runtime.
+
+import * as amqp from '../index';
+import { Options, SocketOptions } from '../lib/properties';
+
+async function testConnect() {
+  // connect with string URL
+  const conn1: amqp.ChannelModel = await amqp.connect('amqp://localhost');
+
+  // connect with Options.Connect object
+  const opts: Options.Connect = {
+    protocol: 'amqp',
+    hostname: 'localhost',
+    port: 5672,
+    username: 'guest',
+    password: 'guest',
+    vhost: '/',
+    heartbeat: 60,
+    frameMax: 131072,
+    channelMax: 0,
+  };
+  const conn2: amqp.ChannelModel = await amqp.connect(opts);
+
+  // connect with SocketOptions including TLS fields
+  const sockOpts: SocketOptions = {
+    noDelay: true,
+    timeout: 5000,
+    keepAlive: true,
+    keepAliveDelay: 1000,
+    clientProperties: { appName: 'test' },
+    rejectUnauthorized: false, // tls.ConnectionOptions field
+  };
+  const conn3: amqp.ChannelModel = await amqp.connect('amqps://localhost', sockOpts);
+
+  return [conn1, conn2, conn3];
+}
+
+async function testChannelModel(conn: amqp.ChannelModel) {
+  // ChannelModel properties
+  const _connection: amqp.Connection = conn.connection;
+  const _serverProps: amqp.ServerProperties = conn.connection.serverProperties;
+
+  // create channels
+  const ch: amqp.Channel = await conn.createChannel();
+  const chWithOpts: amqp.Channel = await conn.createChannel({ highWaterMark: 1024 });
+  const confirmCh: amqp.ConfirmChannel = await conn.createConfirmChannel();
+
+  await conn.updateSecret(Buffer.from('newsecret'), 'rotation');
+  await conn.close();
+
+  return [ch, chWithOpts, confirmCh];
+}
+
+async function testChannel(ch: amqp.Channel) {
+  // assertQueue — queue name is optional (server-named queues)
+  const q1: amqp.Replies.AssertQueue = await ch.assertQueue();
+  const q2: amqp.Replies.AssertQueue = await ch.assertQueue('');
+  const q3: amqp.Replies.AssertQueue = await ch.assertQueue('myqueue', {
+    durable: true,
+    exclusive: false,
+    autoDelete: false,
+    messageTtl: 60000,
+    expires: 300000,
+    deadLetterExchange: 'dlx',
+    deadLetterRoutingKey: 'dlrk',
+    maxLength: 1000,
+    maxPriority: 10,
+    overflow: 'drop-head',
+    queueMode: 'lazy',
+  });
+  void [q1, q2, q3];
+
+  await ch.checkQueue('myqueue');
+  await ch.deleteQueue('myqueue', { ifUnused: true, ifEmpty: true });
+  await ch.purgeQueue('myqueue');
+
+  await ch.bindQueue('myqueue', 'myexchange', 'routing.key');
+  await ch.unbindQueue('myqueue', 'myexchange', 'routing.key');
+
+  // assertExchange — type literal union
+  await ch.assertExchange('myexchange', 'direct', { durable: true });
+  await ch.assertExchange('myexchange', 'topic');
+  await ch.assertExchange('myexchange', 'fanout');
+  await ch.assertExchange('myexchange', 'headers');
+  await ch.assertExchange('myexchange', 'x-custom-type'); // still valid via `string`
+
+  await ch.checkExchange('myexchange');
+  await ch.deleteExchange('myexchange', { ifUnused: false });
+
+  await ch.bindExchange('dest', 'src', 'pattern');
+  await ch.unbindExchange('dest', 'src', 'pattern');
+
+  // publish / sendToQueue
+  const published: boolean = ch.publish('ex', 'rk', Buffer.from('hello'), {
+    persistent: true,
+    contentType: 'application/json',
+    headers: { 'x-custom': 'value' },
+    correlationId: 'abc',
+    replyTo: 'reply-queue',
+    messageId: 'msg-1',
+    timestamp: Date.now(),
+    type: 'event',
+    appId: 'myapp',
+  });
+  const sent: boolean = ch.sendToQueue('q', Buffer.from('hello'));
+  void [published, sent];
+
+  // consume
+  const consumeReply: amqp.Replies.Consume = await ch.consume('q', (msg) => {
+    if (msg !== null) {
+      const _content: Buffer = msg.content;
+      const _tag: string = msg.fields.consumerTag;
+      ch.ack(msg);
+    }
+  });
+  void consumeReply;
+
+  await ch.cancel('consumer-tag');
+
+  // get
+  const msg = await ch.get('q', { noAck: false });
+  if (msg !== false) {
+    const _content: Buffer = msg.content;
+    const _count: number = msg.fields.messageCount;
+    ch.ack(msg);
+  }
+
+  // ack / nack / reject
+  const fakeMsg = {} as amqp.Message;
+  ch.ack(fakeMsg, false);
+  ch.ackAll();
+  ch.nack(fakeMsg, false, true);
+  ch.nackAll(true);
+  ch.reject(fakeMsg, false);
+
+  await ch.prefetch(10);
+  await ch.prefetch(10, true);
+  await ch.recover();
+
+  await ch.close();
+}
+
+async function testConfirmChannel(ch: amqp.ConfirmChannel) {
+  ch.publish('ex', 'rk', Buffer.from('hello'), {}, (err, _ok) => {
+    if (err) console.error(err);
+  });
+  ch.sendToQueue('q', Buffer.from('hello'), {}, (err, _ok) => {
+    if (err) console.error(err);
+  });
+  await ch.waitForConfirms();
+}
+
+function testCredentials() {
+  const plain = amqp.credentials.plain('user', 'pass');
+  const _mech1: string = plain.mechanism;
+  const _resp1: Buffer = plain.response();
+  const _user: string = plain.username;
+  const _pass: string = plain.password;
+
+  const amqplain = amqp.credentials.amqplain('user', 'pass');
+  const _mech2: string = amqplain.mechanism;
+
+  const external = amqp.credentials.external();
+  const _mech3: string = external.mechanism;
+  const _resp3: Buffer = external.response();
+}
+
+function testIllegalOperationError() {
+  const err = new amqp.IllegalOperationError('channel closed');
+  const _name: 'IllegalOperationError' = err.name;
+  const _stack: string | undefined = err.stackAtStateChange;
+  const _msg: string = err.message;
+}
+
+// Exercise re-exports from lib/properties
+function testReExports() {
+  const _opts: Options.Publish = { persistent: true };
+  const _getOpts: Options.Get = { noAck: true };
+}


### PR DESCRIPTION
## Summary

- Adds bundled `.d.ts` files (`index.d.ts`, `callback_api.d.ts`, `lib/properties.d.ts`) so TypeScript users get types automatically on install without needing `@types/amqplib`
- Adds `"types"` and `"exports"` fields to `package.json` for correct type resolution
- Fixes several bugs present in the DefinitelyTyped types: `assertQueue` queue name is now optional, `Connection` no longer exposes internal fields, `Options.Connect` gains `channelMax` and `credentials`, `Options.AssertQueue` gains `overflow` and `queueMode`, `createChannel`/`createConfirmChannel` accept optional `ChannelOptions`, and `IllegalOperationError` is now exported
- Type-level tests in `types/` verified by `tsc --noEmit`
- `typecheck` script wired into CI and pre-commit hook

Closes #843

🤖 Generated with [Claude Code](https://claude.com/claude-code)