### PR TITLE
Fix: update-secret-ok event not forwarded by ChannelModel/CallbackModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log for amqplib
 
 ## Unreleased
+- Fix `update-secret-ok` event not being forwarded by `ChannelModel` and `CallbackModel` (fixes #849)
 - Add `handler-error` event to connections and channels. If a user-supplied event handler (e.g. `connection.on('close', ...)`, `channel.on('error', ...)`, `channel.on('delivery', ...)` etc.) throws a synchronous error, amqplib will emit a `handler-error` event on the same emitter with the thrown error and the name of the event whose handler threw — provided a `handler-error` listener is registered. If no `handler-error` listener is registered, behaviour is unchanged from previous versions. Note: in previous versions, errors thrown in connection `close` event handlers were silently swallowed; errors thrown in channel event handlers (other than `delivery`/`return`) would kill the channel and possibly the connection (fixes #334).
 
 ## v1.0.6

--- a/lib/callback_model.js
+++ b/lib/callback_model.js
@@ -7,7 +7,7 @@ class CallbackModel extends EventEmitter {
   constructor(connection) {
     super();
     this.connection = connection;
-    ['error', 'close', 'blocked', 'unblocked'].forEach((ev) => {
+    ['error', 'close', 'blocked', 'unblocked', 'update-secret-ok'].forEach((ev) => {
       connection.on(ev, this.emit.bind(this, ev));
     });
   }

--- a/lib/channel_model.js
+++ b/lib/channel_model.js
@@ -10,7 +10,7 @@ class ChannelModel extends EventEmitter {
     super();
     this.connection = connection;
 
-    ['error', 'close', 'blocked', 'unblocked'].forEach((ev) => {
+    ['error', 'close', 'blocked', 'unblocked', 'update-secret-ok'].forEach((ev) => {
       connection.on(ev, this.emit.bind(this, ev));
     });
   }

--- a/test/callback_api.test.js
+++ b/test/callback_api.test.js
@@ -42,6 +42,17 @@ describe('Callback API', () => {
         });
       });
     });
+
+    it('emits update-secret-ok event', (_t, done) => {
+      connect((err, _c) => {
+        assert.ifError(err);
+        c = _c;
+        c.on('update-secret-ok', () => done());
+        c.updateSecret(Buffer.from('new secret'), 'no reason', (err) => {
+          assert.ifError(err);
+        });
+      });
+    });
   });
 
   const channel_test_fn = (method) => {

--- a/test/channel_api.test.js
+++ b/test/channel_api.test.js
@@ -25,6 +25,15 @@ describe('updateSecret', () => {
         .finally(() => c.close())
     );
   });
+
+  it('emits update-secret-ok event', () => {
+    return connect().then((c) =>
+      new Promise((resolve, reject) => {
+        c.on('update-secret-ok', resolve);
+        c.updateSecret(Buffer.from('new secret'), 'no reason').catch(reject);
+      }).finally(() => c.close())
+    );
+  });
 });
 
 describe('assert, check, delete', () => {


### PR DESCRIPTION
Fixes #849.

Both `ChannelModel` and `CallbackModel` forward `error`, `close`, `blocked`, and `unblocked` from the underlying `Connection`, but `update-secret-ok` was missing from the list. Users listening for this event on the object returned by `connect()` would never receive it.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)