### PR TITLE
Make heartbeat:0 disable heartbeats

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -59,7 +59,7 @@ function openFrames(vhost, query, credentials, extraClientProperties) {
     // tune-ok
     channelMax: intOrDefault(query.channelMax, 0),
     frameMax: intOrDefault(query.frameMax, 131072),
-    heartbeat: intOrDefault(query.heartbeat, 0),
+    heartbeat: query.heartbeat != null ? intOrDefault(query.heartbeat, 0) : null,
 
     // open
     virtualHost: vhost,

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -159,7 +159,13 @@ class Connection extends EventEmitter {
           const fields = reply.fields;
           tunedOptions.frameMax = negotiate(fields.frameMax, allFields.frameMax);
           tunedOptions.channelMax = negotiate(fields.channelMax, allFields.channelMax);
-          tunedOptions.heartbeat = negotiate(fields.heartbeat, allFields.heartbeat);
+          if (allFields.heartbeat == null) {
+            tunedOptions.heartbeat = fields.heartbeat; // no preference, accept server value
+          } else if (allFields.heartbeat === 0) {
+            tunedOptions.heartbeat = 0; // explicitly disable heartbeats
+          } else {
+            tunedOptions.heartbeat = negotiate(fields.heartbeat, allFields.heartbeat);
+          }
           try {
             send(defs.ConnectionTuneOk);
             send(defs.ConnectionOpen);

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -696,6 +696,77 @@ describe('Connection', () => {
         .then(cb, cb);
       // conspicuously not sending anything ...
     }));
+
+    it('without a heartbeat option, server suggested value is used', connectionTest((c, cb) => {
+      // OPEN_OPTS.heartbeat is null — no preference set by client
+      c.once('error', (err) => {
+        assert.match(err.message, /Heartbeat timeout/);
+        cb();
+      });
+      c.open(OPEN_OPTS, (err) => {
+        assert.ifError(err);
+        assert.strictEqual(c.heartbeat, 1);
+      });
+    }, (send, wait, cb) => {
+      send(defs.ConnectionStart, {
+        versionMajor: 0, versionMinor: 9,
+        serverProperties: {},
+        mechanisms: Buffer.from('PLAIN'),
+        locales: Buffer.from('en_US'),
+      });
+      wait(defs.ConnectionStartOk)()
+        .then(() => send(defs.ConnectionTune, { channelMax: 0, heartbeat: 1, frameMax: 0 }))
+        .then(wait(defs.ConnectionTuneOk))
+        .then(wait(defs.ConnectionOpen))
+        .then(() => send(defs.ConnectionOpenOk, { knownHosts: '' }))
+        .then(cb, cb);
+    }));
+
+    it('heartbeat:0 means no heartbeater is started', connectionTest((c, cb) => {
+      const opts = Object.create(OPEN_OPTS);
+      opts.heartbeat = 0;
+      c.open(opts, (err) => {
+        assert.ifError(err);
+        assert.strictEqual(c.heartbeat, 0);
+        assert.strictEqual(c.heartbeater, null);
+        cb();
+      });
+    }, (send, wait, cb) => {
+      send(defs.ConnectionStart, {
+        versionMajor: 0, versionMinor: 9,
+        serverProperties: {},
+        mechanisms: Buffer.from('PLAIN'),
+        locales: Buffer.from('en_US'),
+      });
+      wait(defs.ConnectionStartOk)()
+        .then(() => send(defs.ConnectionTune, { channelMax: 0, heartbeat: 60, frameMax: 0 }))
+        .then(wait(defs.ConnectionTuneOk))
+        .then(wait(defs.ConnectionOpen))
+        .then(() => send(defs.ConnectionOpenOk, { knownHosts: '' }))
+        .then(cb, cb);
+    }));
+
+    it('heartbeat:0 disables heartbeats even if server suggests one', connectionTest((c, cb) => {
+      const opts = Object.create(OPEN_OPTS);
+      opts.heartbeat = 0;
+      c.open(opts, cb);
+    }, (send, wait, cb) => {
+      send(defs.ConnectionStart, {
+        versionMajor: 0, versionMinor: 9,
+        serverProperties: {},
+        mechanisms: Buffer.from('PLAIN'),
+        locales: Buffer.from('en_US'),
+      });
+      wait(defs.ConnectionStartOk)()
+        .then(() => send(defs.ConnectionTune, { channelMax: 0, heartbeat: 60, frameMax: 0 }))
+        .then(wait(defs.ConnectionTuneOk))
+        .then((tuneOk) => {
+          assert.strictEqual(tuneOk.fields.heartbeat, 0);
+        })
+        .then(wait(defs.ConnectionOpen))
+        .then(() => send(defs.ConnectionOpenOk, { knownHosts: '' }))
+        .then(cb, cb);
+    }));
   });
 
 });

--- a/test/lib/data.js
+++ b/test/lib/data.js
@@ -214,7 +214,7 @@ const OPEN_OPTS = {
   // tune-ok
   channelMax: 0,
   frameMax: 0,
-  heartbeat: 0,
+  heartbeat: null,
 
   // open
   virtualHost: '/',


### PR DESCRIPTION
**BREAKING CHANGE** — bump to v2.0.0.

`heartbeat: 0` now correctly disables heartbeats, sending `0` in the `ConnectionTuneOk` frame regardless of the server's suggestion. This aligns with the AMQP 0-9-1 spec, which defines `heartbeat=0` as "disabled".

Previously, `0` was passed through `negotiate()` which treated it as "no preference", causing the server's suggested value to be used instead. The code even had a comment acknowledging the correct intent: *"0 means no heartbeat, rather than maximum period of heartbeating"*.

**Migration:** if you are passing `heartbeat: 0` and want to preserve the old behaviour of accepting the server's value, omit the option or pass `null` instead.

Closes #467. Supersedes #469.

🤖 Generated with [Claude Code](https://claude.com/claude-code)