### PR TITLE
Remove buffer-more-ints, use Node.js built-in BigInt Buffer methods

### DIFF
--- a/bin/generate-defs.js
+++ b/bin/generate-defs.js
@@ -113,7 +113,6 @@ println("'use strict';");
 nl();
 nl();
 println('var codec = require("./codec");');
-println('var ints = require("buffer-more-ints");');
 println('var encodeTable = codec.encodeTable;');
 println('var decodeFields = codec.decodeFields;');
 nl();
@@ -412,7 +411,7 @@ function encoderFn(method) {
       case 'longlong':
       case 'timestamp':
         checkAssignArg(a);
-        println('ints.writeUInt64BE(buffer, val, offset); offset += 8;');
+        println('buffer.writeBigUInt64BE(BigInt(val), offset); offset += 8;');
         break;
       case 'bit':
         checkAssignArg(a);
@@ -493,7 +492,7 @@ function decoderFn(method) {
         break;
       case 'longlong':
       case 'timestamp':
-        println('val = ints.readUInt64BE(buffer, offset); offset += 8;');
+        println('val = Number(buffer.readBigUInt64BE(offset)); offset += 8;');
         break;
       case 'bit': {
         const bit = 1 << bitsInARow;
@@ -612,7 +611,7 @@ function encodePropsFn(props) {
   // skip frame size for now, we'll write it in when we know.
 
   // body size
-  println('ints.writeUInt64BE(buffer, size, 11);');
+  println('buffer.writeBigUInt64BE(BigInt(size), 11);');
 
   println('flags = 0;');
   // we'll write the flags later too
@@ -642,7 +641,7 @@ function encodePropsFn(props) {
           break;
         case 'longlong':
         case 'timestamp':
-          println('ints.writeUInt64BE(buffer, val, offset);');
+          println('buffer.writeBigUInt64BE(BigInt(val), offset);');
           println('offset += 8;');
           break;
         case 'shortstr': {
@@ -706,7 +705,7 @@ function decodePropsFn(props) {
           break;
         case 'longlong':
         case 'timestamp':
-          println('val = ints.readUInt64BE(buffer, offset); offset += 8;');
+          println('val = Number(buffer.readBigUInt64BE(offset)); offset += 8;');
           break;
         case 'longstr':
           println('len = buffer.readUInt32BE(offset); offset += 4;');

--- a/lib/codec.js
+++ b/lib/codec.js
@@ -45,8 +45,6 @@ properties are present. This scheme can save ones of bytes per message
 (messages which take a minimum of three frames each to send).
 */
 
-const ints = require('buffer-more-ints');
-
 // JavaScript uses only doubles so what I'm testing for is whether
 // it's *better* to encode a number as a float or double. This really
 // just amounts to testing whether there's a fractional part to the
@@ -219,7 +217,7 @@ function encodeFieldValue(buffer, value, offset) {
     case 'long':
     case 'int64':
       tag('l');
-      ints.writeInt64BE(buffer, val, offset);
+      buffer.writeBigInt64BE(BigInt(val), offset);
       offset += 8;
       break;
 
@@ -227,7 +225,7 @@ function encodeFieldValue(buffer, value, offset) {
     // `{'!': type, value: val}
     case 'timestamp':
       tag('T');
-      ints.writeUInt64BE(buffer, val, offset);
+      buffer.writeBigUInt64BE(BigInt(val), offset);
       offset += 8;
       break;
     case 'float':
@@ -296,7 +294,7 @@ function decodeFields(slice) {
         break;
       }
       case 'T':
-        val = ints.readUInt64BE(slice, offset);
+        val = Number(slice.readBigUInt64BE(offset));
         offset += 8;
         val = { '!': 'timestamp', value: val };
         break;
@@ -321,7 +319,7 @@ function decodeFields(slice) {
         offset += 4;
         break;
       case 'l':
-        val = ints.readInt64BE(slice, offset);
+        val = Number(slice.readBigInt64BE(offset));
         offset += 8;
         break;
       case 's':

--- a/lib/defs.js
+++ b/lib/defs.js
@@ -501,7 +501,7 @@ function decodeBasicDeliver(buffer) {
   val = buffer.toString('utf8', offset, offset + len);
   offset += len;
   fields.consumerTag = val;
-  val = ints.readUInt64BE(buffer, offset);
+  val = Number(buffer.readBigUInt64BE(offset));
   offset += 8;
   fields.deliveryTag = val;
   val = !!(1 & buffer[offset]);
@@ -557,7 +557,7 @@ function encodeBasicDeliver(channel, fields) {
   val = fields.deliveryTag;
   if (void 0 === val) throw new Error("Missing value for mandatory field 'deliveryTag'");
   if ('number' != typeof val || isNaN(val)) throw new TypeError("Field 'deliveryTag' is the wrong type; must be a number (but not NaN)");
-  ints.writeUInt64BE(buffer, val, offset);
+  buffer.writeBigUInt64BE(BigInt(val), offset);
   offset += 8;
   val = fields.redelivered;
   void 0 === val && (val = !1);
@@ -652,7 +652,7 @@ function decodeBasicGetOk(buffer) {
       routingKey: void 0,
       messageCount: void 0,
     };
-  val = ints.readUInt64BE(buffer, offset);
+  val = Number(buffer.readBigUInt64BE(offset));
   offset += 8;
   fields.deliveryTag = val;
   val = !!(1 & buffer[offset]);
@@ -699,7 +699,7 @@ function encodeBasicGetOk(channel, fields) {
   val = fields.deliveryTag;
   if (void 0 === val) throw new Error("Missing value for mandatory field 'deliveryTag'");
   if ('number' != typeof val || isNaN(val)) throw new TypeError("Field 'deliveryTag' is the wrong type; must be a number (but not NaN)");
-  ints.writeUInt64BE(buffer, val, offset);
+  buffer.writeBigUInt64BE(BigInt(val), offset);
   offset += 8;
   val = fields.redelivered;
   void 0 === val && (val = !1);
@@ -777,7 +777,7 @@ function decodeBasicAck(buffer) {
       deliveryTag: void 0,
       multiple: void 0,
     };
-  val = ints.readUInt64BE(buffer, offset);
+  val = Number(buffer.readBigUInt64BE(offset));
   offset += 8;
   fields.deliveryTag = val;
   val = !!(1 & buffer[offset]);
@@ -798,7 +798,7 @@ function encodeBasicAck(channel, fields) {
   if (void 0 === val) val = 0;
   else if ('number' != typeof val || isNaN(val))
     throw new TypeError("Field 'deliveryTag' is the wrong type; must be a number (but not NaN)");
-  ints.writeUInt64BE(buffer, val, offset);
+  buffer.writeBigUInt64BE(BigInt(val), offset);
   offset += 8;
   val = fields.multiple;
   void 0 === val && (val = !1);
@@ -817,7 +817,7 @@ function decodeBasicReject(buffer) {
       deliveryTag: void 0,
       requeue: void 0,
     };
-  val = ints.readUInt64BE(buffer, offset);
+  val = Number(buffer.readBigUInt64BE(offset));
   offset += 8;
   fields.deliveryTag = val;
   val = !!(1 & buffer[offset]);
@@ -837,7 +837,7 @@ function encodeBasicReject(channel, fields) {
   val = fields.deliveryTag;
   if (void 0 === val) throw new Error("Missing value for mandatory field 'deliveryTag'");
   if ('number' != typeof val || isNaN(val)) throw new TypeError("Field 'deliveryTag' is the wrong type; must be a number (but not NaN)");
-  ints.writeUInt64BE(buffer, val, offset);
+  buffer.writeBigUInt64BE(BigInt(val), offset);
   offset += 8;
   val = fields.requeue;
   void 0 === val && (val = !0);
@@ -931,7 +931,7 @@ function decodeBasicNack(buffer) {
       multiple: void 0,
       requeue: void 0,
     };
-  val = ints.readUInt64BE(buffer, offset);
+  val = Number(buffer.readBigUInt64BE(offset));
   offset += 8;
   fields.deliveryTag = val;
   val = !!(1 & buffer[offset]);
@@ -954,7 +954,7 @@ function encodeBasicNack(channel, fields) {
   if (void 0 === val) val = 0;
   else if ('number' != typeof val || isNaN(val))
     throw new TypeError("Field 'deliveryTag' is the wrong type; must be a number (but not NaN)");
-  ints.writeUInt64BE(buffer, val, offset);
+  buffer.writeBigUInt64BE(BigInt(val), offset);
   offset += 8;
   val = fields.multiple;
   void 0 === val && (val = !1);
@@ -3313,7 +3313,7 @@ function encodeBasicProperties(channel, size, fields) {
   buffer[0] = 2;
   buffer.writeUInt16BE(channel, 1);
   buffer.writeUInt32BE(3932160, 7);
-  ints.writeUInt64BE(buffer, size, 11);
+  buffer.writeBigUInt64BE(BigInt(size), 11);
   flags = 0;
   offset = 21;
   val = fields.contentType;
@@ -3384,7 +3384,7 @@ function encodeBasicProperties(channel, size, fields) {
   val = fields.timestamp;
   if (void 0 != val) {
     flags += 64;
-    ints.writeUInt64BE(buffer, val, offset);
+    buffer.writeBigUInt64BE(BigInt(val), offset);
     offset += 8;
   }
   val = fields.type;
@@ -3508,7 +3508,7 @@ function decodeBasicProperties(buffer) {
     fields.messageId = val;
   }
   if (64 & flags) {
-    val = ints.readUInt64BE(buffer, offset);
+    val = Number(buffer.readBigUInt64BE(offset));
     offset += 8;
     fields.timestamp = val;
   }
@@ -3544,7 +3544,6 @@ function decodeBasicProperties(buffer) {
 }
 
 var codec = require('./codec'),
-  ints = require('buffer-more-ints'),
   encodeTable = codec.encodeTable,
   decodeFields = codec.decodeFields,
   SCRATCH = Buffer.alloc(65536),

--- a/lib/frame.js
+++ b/lib/frame.js
@@ -1,4 +1,3 @@
-const ints = require('buffer-more-ints');
 const defs = require('./defs');
 const constants = defs.constants;
 const decode = defs.decode;
@@ -43,22 +42,8 @@ const FRAME_END_BYTES = 1;
  * }} FrameStructure
  */
 
-/**
- * This is a polyfill which will read a big int 64 bit as a number.
- * @arg { Buffer } buffer
- * @arg { number } offset
- * @returns { number }
- */
 function readInt64BE(buffer, offset) {
-  /**
-   * We try to use native implementation if available here because
-   * buffer-more-ints does not
-   */
-  if (typeof Buffer.prototype.readBigInt64BE === 'function') {
-    return Number(buffer.readBigInt64BE(offset));
-  }
-
-  return ints.readInt64BE(buffer, offset);
+  return Number(buffer.readBigInt64BE(offset));
 }
 
 // %%% TESTME possibly better to cons the first bit and write the

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "amqplib",
       "version": "2.0.0",
       "license": "MIT",
-      "dependencies": {
-        "buffer-more-ints": "~1.0.0"
-      },
       "devDependencies": {
         "@biomejs/biome": "^2.2.2",
         "@types/node": "^25.6.0",
@@ -215,11 +212,6 @@
       "resolved": "https://registry.npmjs.org/boo/-/boo-1.2.4.tgz",
       "integrity": "sha1-szMxw2xK552C9P0ORJBgTLfFE7U=",
       "dev": true
-    },
-    "node_modules/buffer-more-ints": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz",
-      "integrity": "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg=="
     },
     "node_modules/camelcase": {
       "version": "1.2.1",
@@ -694,11 +686,6 @@
       "resolved": "https://registry.npmjs.org/boo/-/boo-1.2.4.tgz",
       "integrity": "sha1-szMxw2xK552C9P0ORJBgTLfFE7U=",
       "dev": true
-    },
-    "buffer-more-ints": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz",
-      "integrity": "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg=="
     },
     "camelcase": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,7 @@
   "engines": {
     "node": ">=18"
   },
-  "dependencies": {
-    "buffer-more-ints": "~1.0.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@biomejs/biome": "^2.2.2",
     "@types/node": "^25.6.0",

--- a/test/codec.test.js
+++ b/test/codec.test.js
@@ -1,6 +1,5 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert');
-const ints = require('buffer-more-ints');
 const { forAll } = require('claire');
 const codec = require('../lib/codec');
 const defs = require('../lib/defs');
@@ -152,7 +151,7 @@ describe('Codec', () => {
       const buf = defs.encodeProperties(properties.id, 0, properties.size, properties.fields);
       // FIXME depends on framing, ugh
       const fs1 = defs.decode(properties.id, buf.subarray(19, buf.length));
-      assert.equal(properties.size, ints.readUInt64BE(buf, 11));
+      assert.equal(properties.size, Number(buf.readBigUInt64BE(11)));
       assertEqualModuloDefaults(properties, fs1);
       return true;
     });


### PR DESCRIPTION
Node.js has had `readBigInt64BE`/`readBigUInt64BE`/`writeBigInt64BE`/`writeBigUInt64BE` since v10.4. amqplib requires Node 18+, so `buffer-more-ints` is no longer needed.

Replace all usages in `lib/codec.js`, `lib/frame.js`, and the `bin/generate-defs.js` template (then regenerate `lib/defs.js`). Wrap with `Number()`/`BigInt()` to preserve existing return types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)